### PR TITLE
Fix B1I timing and dynamic navbits

### DIFF
--- a/bdssim.c
+++ b/bdssim.c
@@ -13,7 +13,6 @@
 
 #define FSAMP     8.184e6
 #define SAMP_1MS  8184
-#define STEP_MS   10          /* 幾何更新粒度 */
 
 static const int geo[] ={1,2,3,4,5,59,60,61,62,63};
 static int is_geo(int p){for(int i=0;i<10;i++) if(p==geo[i]) return 1; return 0;}
@@ -45,7 +44,7 @@ void generate_signal(const sim_config_t *cfg)
     coord_t usr={0}; llh2xyz(cfg->llh,&usr);
     if(utc_to_bdt(cfg->time_start,&usr.week,&usr.sow)!=0){fputs("UTC format err\n",stderr);return;}
 
-    navbits_init(usr.week, usr.sow);
+    navbits_init();
 
     channel_t ch[MAX_CH]; int n_ch; select_channels(ch,&n_ch,&usr);
 
@@ -62,6 +61,7 @@ void generate_signal(const sim_config_t *cfg)
     int16_t tmpI[MAX_CH][SAMP_1MS],tmpQ[MAX_CH][SAMP_1MS];
     int32_t accI[SAMP_1MS],accQ[SAMP_1MS],outI[SAMP_1MS],outQ[SAMP_1MS];
 
+    const int STEP_MS = cfg->step_ms;
     const uint64_t total_ms=(uint64_t)cfg->duration*1000;
     for(uint64_t ms=0; ms<total_ms; ms+=STEP_MS)
     {
@@ -82,7 +82,8 @@ void generate_signal(const sim_config_t *cfg)
             /* 併行各通道 */
             #pragma omp parallel for
             for(int c=0;c<n_ch;++c)
-                gen_samples_1ms(&ch[c],tmpI[c],tmpQ[c]);
+                gen_samples_1ms(&ch[c],usr.week,sow+step*0.001,
+                               tmpI[c],tmpQ[c]);
 
             /* 歸併 */
             for(int c=0;c<n_ch;++c)
@@ -99,7 +100,7 @@ void generate_signal(const sim_config_t *cfg)
             fwrite(outI,2,SAMP_1MS,fp);
             fwrite(outQ,2,SAMP_1MS,fp);
         }
-        /* 進度 0.01 s = STEP_MS ms */
+        /* 進度顯示 */
         printf("\r進度: %.2f / %.2f 秒",(ms+STEP_MS)/1000.0,total_ms/1000.0);
         fflush(stdout);
     }

--- a/channel.c
+++ b/channel.c
@@ -61,10 +61,11 @@ void update_channel_dynamics(channel_t *c,double rho,double rdot,int n_ch){
 }
 
 /* ---------- 產生 1 ms ---------- */
-void gen_samples_1ms(channel_t *c,int16_t*I,int16_t*Q)
+void gen_samples_1ms(channel_t *c,int week,double sow,int16_t*I,int16_t*Q)
 {
     static uint8_t nav[300];
-    if(c->bit_ptr==0) get_subframe_bits(c->prn,c->sf_id,nav);
+    if(c->bit_ptr==0 && c->ms_count==0)
+        get_subframe_bits(c->prn,c->sf_id,week,sow,nav);
 
     const double dphi = PI2*(FCARRIER + c->fd)/FS;
     const double dcode = c->code_rate/FS;     /* chips per sample */
@@ -83,8 +84,15 @@ void gen_samples_1ms(channel_t *c,int16_t*I,int16_t*Q)
         /* NCO */
         phase += dphi; if(phase>=PI2) phase-=PI2;
         code_phase += dcode;
-        if(code_phase>=CODE_LEN){ code_phase-=CODE_LEN;
-            if(++c->bit_ptr==300){ c->bit_ptr=0; c->sf_id=c->sf_id%3+1;}
+        if(code_phase>=CODE_LEN){
+            code_phase-=CODE_LEN;
+            if(++c->ms_count==20){
+                c->ms_count=0;
+                if(++c->bit_ptr==300){
+                    c->bit_ptr=0;
+                    c->sf_id=c->sf_id%3+1;
+                }
+            }
         }
     }
     c->carr_phase = phase;

--- a/channel.h
+++ b/channel.h
@@ -17,14 +17,17 @@ typedef struct {
     uint16_t code_ptr;
     uint16_t bit_ptr;
     uint8_t  sf_id;
+    uint8_t  ms_count;      /* 0~19: ms index within data bit */
 } channel_t;
 
 void channel_reset(channel_t *, int prn);
 void update_channel_dynamics(channel_t *, double rho, double rdot, int n_ch);
-void gen_samples_1ms(channel_t *, int16_t *I, int16_t *Q);
+void gen_samples_1ms(channel_t *, int week, double sow,
+                     int16_t *I, int16_t *Q);
 
 /* === 修正：用指標而非 array declarator === */
-void get_subframe_bits(int prn, int sf_id, uint8_t *out);   /* out[300] */
+void get_subframe_bits(int prn, int sf_id, int week, double sow,
+                       uint8_t *out);   /* out[300] */
 
 #endif
 

--- a/main.c
+++ b/main.c
@@ -21,7 +21,7 @@ int main(int argc,char *argv[])
     sim_config_t cfg = {0};
     cfg.sample_rate = 8184000;
     cfg.gain        = 1.0;
-    cfg.step_ms     = 10;
+    cfg.step_ms     = 1;
     cfg.duration    = 300;                /* 預設 300 秒 */
 
     /* 2. 解析 CLI ----------------------------------- */

--- a/navbits.c
+++ b/navbits.c
@@ -132,20 +132,27 @@ static void build_subframe3(uint8_t *out, const ephemeris_t *e)
 }
 
 /* ---------------------------------------------------------------------------- */
-static uint8_t sf_bits[MAX_SAT][3][SF_STREAM_LEN]; /* PRN×子帧×bits */
+static uint8_t sf_static[MAX_SAT][2][SF_STREAM_LEN]; /* subframe 2 & 3 */
 
-void navbits_init(int week,double sow)
+void navbits_init(void)
 {
     for(int prn=1;prn<=63;prn++){
-        build_subframe1(sf_bits[prn][0], &eph[prn], week, sow);
-        build_subframe2(sf_bits[prn][1], &eph[prn]);
-        build_subframe3(sf_bits[prn][2], &eph[prn]);
+        build_subframe2(sf_static[prn][0], &eph[prn]);
+        build_subframe3(sf_static[prn][1], &eph[prn]);
     }
 }
 
-/* 取出子帧 bit 流 (300 bits) */
-void get_subframe_bits(int prn,int sf_id,uint8_t *out)
+/* 根據時間取得子帧 bit 流 (300 bits) */
+void get_subframe_bits(int prn,int sf_id,int week,double sow,uint8_t *out)
 {
-    memcpy(out,sf_bits[prn][sf_id-1],SF_STREAM_LEN);
+    if(sf_id==1){
+        build_subframe1(out,&eph[prn],week,sow);
+    }else if(sf_id==2){
+        memcpy(out,sf_static[prn][0],SF_STREAM_LEN);
+    }else if(sf_id==3){
+        memcpy(out,sf_static[prn][1],SF_STREAM_LEN);
+    }else{
+        memset(out,0,SF_STREAM_LEN);
+    }
 }
 

--- a/navbits.h
+++ b/navbits.h
@@ -10,8 +10,8 @@
 
 #define SF_STREAM_LEN (SUBFRAME_BITS)
 
-void navbits_init(int bdt_week, double sow);
-void get_subframe_bits(int prn, int sf_id, uint8_t *out); /* sf_id=1,2,3 */
+void navbits_init(void);
+void get_subframe_bits(int prn, int sf_id, int week, double sow, uint8_t *out); /* sf_id=1,2,3 */
 
 #endif
 


### PR DESCRIPTION
## Summary
- update default step to 1 ms
- compute channel data bits over 20 ms intervals
- generate subframe 1 on demand with current time
- recompute geometry every step and pass time to `gen_samples_1ms`

## Testing
- `make`
- `make clean`

------
https://chatgpt.com/codex/tasks/task_e_68634c50447c83278b2dd859ff7cb92e