### PR TITLE
Add placeholder subframes 4 and 5

### DIFF
--- a/navbits.c
+++ b/navbits.c
@@ -131,14 +131,40 @@ static void build_subframe3(uint8_t *out, const ephemeris_t *e)
     for(int i=0;i<HALF_SUBFRAME_BITS;i++) out[i+HALF_SUBFRAME_BITS]=out[i];
 }
 
+/* --------------------------------- 子帧 4 ----------------------------------- */
+static void build_subframe4(uint8_t *out)
+{
+    memset(out,0,SF_STREAM_LEN);
+    uint16_t info = 0x712;            /* sync */
+    info = ((info<<3)|0x4) & 0x7FF;   /* FraID=100 */
+    put_word(out,0, make_word30(info));
+    for(int w=1; w<10; ++w)
+        put_word(out,w*30, make_word30(0));
+    for(int i=0;i<HALF_SUBFRAME_BITS;i++) out[i+HALF_SUBFRAME_BITS]=out[i];
+}
+
+/* --------------------------------- 子帧 5 ----------------------------------- */
+static void build_subframe5(uint8_t *out)
+{
+    memset(out,0,SF_STREAM_LEN);
+    uint16_t info = 0x712;            /* sync */
+    info = ((info<<3)|0x5) & 0x7FF;   /* FraID=101 */
+    put_word(out,0, make_word30(info));
+    for(int w=1; w<10; ++w)
+        put_word(out,w*30, make_word30(0));
+    for(int i=0;i<HALF_SUBFRAME_BITS;i++) out[i+HALF_SUBFRAME_BITS]=out[i];
+}
+
 /* ---------------------------------------------------------------------------- */
-static uint8_t sf_static[MAX_SAT][2][SF_STREAM_LEN]; /* subframe 2 & 3 */
+static uint8_t sf_static[MAX_SAT][4][SF_STREAM_LEN]; /* subframe 2-5 */
 
 void navbits_init(void)
 {
     for(int prn=1;prn<=63;prn++){
         build_subframe2(sf_static[prn][0], &eph[prn]);
         build_subframe3(sf_static[prn][1], &eph[prn]);
+        build_subframe4(sf_static[prn][2]);
+        build_subframe5(sf_static[prn][3]);
     }
 }
 
@@ -151,6 +177,10 @@ void get_subframe_bits(int prn,int sf_id,int week,double sow,uint8_t *out)
         memcpy(out,sf_static[prn][0],SF_STREAM_LEN);
     }else if(sf_id==3){
         memcpy(out,sf_static[prn][1],SF_STREAM_LEN);
+    }else if(sf_id==4){
+        memcpy(out,sf_static[prn][2],SF_STREAM_LEN);
+    }else if(sf_id==5){
+        memcpy(out,sf_static[prn][3],SF_STREAM_LEN);
     }else{
         memset(out,0,SF_STREAM_LEN);
     }

--- a/navbits.h
+++ b/navbits.h
@@ -11,7 +11,7 @@
 #define SF_STREAM_LEN (SUBFRAME_BITS)
 
 void navbits_init(void);
-void get_subframe_bits(int prn, int sf_id, int week, double sow, uint8_t *out); /* sf_id=1,2,3 */
+void get_subframe_bits(int prn, int sf_id, int week, double sow, uint8_t *out); /* sf_id=1..5 */
 
 #endif
 


### PR DESCRIPTION
## Summary
- implement empty subframe4/5 generation
- expose subframe IDs 1..5 in navbits.h

## Testing
- `make`
- `./bds-sim --rinex BRDM00DLR_S_20251760000_01D_MN.rnx --start 2025/06/25,00:00:00 --duration 1`
- `gcc -O2 -Wall -Wextra test_subframes.c globals.o bch.o navbits.o rinex.o -lm -o test_subframes`
- `./test_subframes`


------
https://chatgpt.com/codex/tasks/task_e_68635231341483278e2c5870f22e7b39