### PR TITLE
Fix baseband generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,10 @@ the simulation start.
 ## SDR playback
 
 The file `beidou_b1i.bin` contains interleaved 16‑bit little‑endian I/Q
-samples at 8.184 MHz. Configure your SDR transmitter to this sample
-rate and set the RF centre frequency to **1561.098 MHz**.  The following
-command illustrates playback with a HackRF:
+samples at 8.184 MHz.  The signal is at baseband (zero‑IF), so tune the
+SDR’s RF centre frequency to the desired transmit frequency – for B1I
+this is typically **1561.098 MHz** – and play the samples at the same
+rate.  The following command illustrates playback with a HackRF:
 
 ```bash
 hackrf_transfer -t beidou_b1i.bin -f 1561098000 -s 8184000 -x 0

--- a/channel.c
+++ b/channel.c
@@ -67,7 +67,8 @@ void gen_samples_1ms(channel_t *c,int week,double sow,int16_t*I,int16_t*Q)
     if(c->bit_ptr==0 && c->ms_count==0)
         get_subframe_bits(c->prn,c->sf_id,week,sow,nav);
 
-    const double dphi = PI2*(FCARRIER + c->fd)/FS;
+    /* Baseband output – only apply Doppler frequency */
+    const double dphi = PI2*c->fd/FS;
     const double dcode = c->code_rate/FS;     /* chips per sample */
     double code_phase = c->code_phase;
     double phase = c->carr_phase;


### PR DESCRIPTION
## Summary
- keep Doppler calculation but remove fixed 1561.098 MHz carrier from the NCO
- clarify that the SDR playback file is zero-IF baseband

## Testing
- `make`
- `./bds-sim --rinex BRDM00DLR_S_20251760000_01D_MN.rnx --start 2025/06/25,00:00:00 --duration 1 --llh 0,0,0`


------
https://chatgpt.com/codex/tasks/task_e_686376d7a5448327806ecc3b4b4da541