### PR TITLE
Fix tk time calculation

### DIFF
--- a/bdssim.c
+++ b/bdssim.c
@@ -19,6 +19,15 @@
 static const int geo[] ={1,2,3,4,5,59,60,61,62,63};
 static int is_geo(int p){for(int i=0;i<10;i++) if(p==geo[i]) return 1; return 0;}
 
+/* ---- Compute user's ECEF velocity due to Earth rotation ---- */
+static void user_ecef_velocity(const coord_t *u,double vel[3])
+{
+    if(!u || !vel){ return; }
+    vel[0] = -OMEGA_E*u->xyz[1];
+    vel[1] =  OMEGA_E*u->xyz[0];
+    vel[2] =  0.0;
+}
+
 /* ---- Rotate fixed LLH with Earth rotation ----- */
 static void static_user_at(int week,double sow,const coord_t*ref,
                            coord_t*out,double vel[3])

--- a/orbits.c
+++ b/orbits.c
@@ -27,8 +27,11 @@ void calc_sat_position_velocity(int prn,int week,double sow,
         return;
     }
 
-    /* ---- 時間差 tk：週差納入並限制在 ±302400 s ---- */
-    double tk = (week - ep->week)*604800.0 + (sow - ep->toe);
+    /* ---- 時間差 tk：採用 GPS 絕對秒數基準，避免週數交界問題 ---- */
+    double simulated_time      = week*604800.0 + sow;
+    double ephemeris_toe_time  = ep->week*604800.0 + ep->toe;
+
+    double tk = simulated_time - ephemeris_toe_time;
     if(tk> 302400) tk-=604800;
     if(tk<-302400) tk+=604800;
 


### PR DESCRIPTION
## Summary
- compute tk using absolute GPS time to match gps-sdr-sim
- add `user_ecef_velocity` helper so build succeeds

## Testing
- `make`
- `make prn_test`


------
https://chatgpt.com/codex/tasks/task_e_6863b55b9db08327be3d5d5afbbad21f