### PR TITLE
Fix signal amplitude control

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,12 @@ may appear to contain only zeros or `-1` values.
 ./bds-sim --rinex BRDM00DLR_S_20251760000_01D_MN.rnx \
           --start 2025/06/25,00:00:00 \
           --duration 60 \
+          --gain 1.0 \
           --llh lat,lon,height
 ```
+
+`--gain` scales the output amplitude. Values greater than 1 boost the
+signal level.
 
 `--start` specifies the UTC start time; `--duration` is in seconds and
 `--llh` defines the user location in degrees and meters.

--- a/bdssim.c
+++ b/bdssim.c
@@ -125,7 +125,7 @@ void generate_signal(const sim_config_t *cfg)
         double dx=sat[0]-usr.xyz[0],dy=sat[1]-usr.xyz[1],dz=sat[2]-usr.xyz[2];
         double rho=hypot(hypot(dx,dy),dz);
         double rdot=(dx*(vel[0]-uvel[0]) + dy*(vel[1]-uvel[1]) + dz*(vel[2]-uvel[2]))/rho;
-        update_channel_dynamics(&ch[i],rho,rdot,n_ch);
+        update_channel_dynamics(&ch[i],rho,rdot,n_ch,cfg->gain);
         printf("PRN%02d t=%.1fs rdot=%.2f fd=%.2fHz\n",
                ch[i].prn, 0.0, rdot, ch[i].fd);
     }
@@ -165,7 +165,7 @@ void generate_signal(const sim_config_t *cfg)
             double dx=sat[0]-usr.xyz[0],dy=sat[1]-usr.xyz[1],dz=sat[2]-usr.xyz[2];
             double rho=hypot(hypot(dx,dy),dz);
             double rdot=(dx*(vel[0]-uvel[0]) + dy*(vel[1]-uvel[1]) + dz*(vel[2]-uvel[2]))/rho;
-            update_channel_dynamics(&ch[i],rho,rdot,n_ch);
+            update_channel_dynamics(&ch[i],rho,rdot,n_ch,cfg->gain);
             printf("PRN%02d t=%.1fs rdot=%.2f fd=%.2fHz\n",
                    ch[i].prn, t_abs-start_bdt, rdot, ch[i].fd);
         }

--- a/channel.c
+++ b/channel.c
@@ -32,9 +32,9 @@ static inline void fast_sincos(double ph,float*co,float*si){
 }
 
 /* ---------- 振幅 ---------- */
-double calc_amp(double rho,int n_ch){
+double calc_amp(double rho,int n_ch,double gain){
     double p = -130.0 - 20.0*log10(rho/2.0e7);
-    return (float)pow(10.0,(p-DBM_REF)/20.0)/n_ch;
+    return gain * (float)pow(10.0,(p-DBM_REF)/20.0)/n_ch;
 }
 
 /* ---------- CA cache ---------- */
@@ -54,8 +54,8 @@ void channel_reset(channel_t *c,int prn){
     }
 }
 /* 幾何→計算振幅 / 初始多普勒 */
-void update_channel_dynamics(channel_t *c,double rho,double rdot,int n_ch){
-    c->amp = calc_amp(rho,n_ch);
+void update_channel_dynamics(channel_t *c,double rho,double rdot,int n_ch,double gain){
+    c->amp = calc_amp(rho,n_ch,gain);
     c->fd  = -FCARRIER*rdot/299792458.0;               /* Hz */
     c->code_rate = CHIPRATE*(1.0+rdot/299792458.0);    /* Hz */
 }

--- a/channel.h
+++ b/channel.h
@@ -22,7 +22,7 @@ typedef struct {
 } channel_t;
 
 void channel_reset(channel_t *, int prn);
-void update_channel_dynamics(channel_t *, double rho, double rdot, int n_ch);
+void update_channel_dynamics(channel_t *, double rho, double rdot, int n_ch, double gain);
 void gen_samples_1ms(channel_t *, int week, double sow,
                      int16_t *I, int16_t *Q);
 

--- a/main.c
+++ b/main.c
@@ -14,7 +14,7 @@ static void usage(const char *p)
     puts("用法:");
     printf("  %s --rinex nav.rnx --start YYYY/MM/DD,hh:mm:ss \n", p);
     puts("     [--llh lat,lon,h] [--xyz file] [--llh-file file] [--nmea file]");
-    puts("     [--duration sec]\n");
+    puts("     [--duration sec] [--gain amp]\n");
 }
 
 int main(int argc,char *argv[])
@@ -35,12 +35,13 @@ int main(int argc,char *argv[])
         {"llh-file", required_argument, 0, 'y'},
         {"nmea",     required_argument, 0, 'n'},
         {"duration", required_argument, 0, 'd'},
+        {"gain",     required_argument, 0, 'g'},
         {"help",     no_argument,       0, 'h'},
         {0,0,0,0}
     };
 
     int c, idx;
-    while((c = getopt_long(argc, argv, "e:t:l:x:y:n:d:h", longopt, &idx)) != -1){
+    while((c = getopt_long(argc, argv, "e:t:l:x:y:n:d:g:h", longopt, &idx)) != -1){
         switch(c){
         case 'e':
             strncpy(cfg.rinex_file, optarg, sizeof(cfg.rinex_file)-1);
@@ -73,6 +74,13 @@ int main(int argc,char *argv[])
             break;
         case 'd':
             cfg.duration = (uint32_t)atoi(optarg);
+            break;
+        case 'g':
+            cfg.gain = atof(optarg);
+            if(cfg.gain <= 0.0){
+                fprintf(stderr,"--gain 必須 >0\n");
+                return 1;
+            }
             break;
         default:
             usage(argv[0]); return 0;
@@ -144,6 +152,7 @@ int main(int argc,char *argv[])
            usr.xyz[0], usr.xyz[1], usr.xyz[2]);
     printf("[cfg] PRN   :");
     for(int i=0;i<n_ch;i++) printf(" %02d", ch[i].prn);
+    printf("\n[cfg] Gain  : %.2f\n", cfg.gain);
     puts("");
 
     /* 4. 產生基帶 ----------------------------------- */


### PR DESCRIPTION
## Summary
- allow setting custom output gain
- pass gain to channel amplitude calculations
- expose `--gain` command line option
- document new option in README

## Testing
- `make`
- `./bds-sim --rinex BRDM00DLR_S_20251760000_01D_MN.rnx --start 2025/06/25,00:00:00 --llh 0,0,0 --duration 1 --gain 2`


------
https://chatgpt.com/codex/tasks/task_e_6863c4482de48327bd9d748c0e1642ef