### PR TITLE
Improve CLI help and summary output

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ signal level.
 
 `--start` specifies the UTC start time; `--duration` is in seconds and
 `--llh` defines the user location in degrees and meters.
+Run `./bds-sim --help` to see all command options. A brief configuration
+summary is printed before signal generation begins.
 
 ### Dynamic user trajectory
 

--- a/bdssim.c
+++ b/bdssim.c
@@ -121,13 +121,13 @@ void generate_signal(const sim_config_t *cfg)
     /* 首次幾何 – 初始化振幅/NCO */
     double uvel0[3]; user_ecef_velocity(&usr,uvel0);
     for(int i=0;i<n_ch;++i){
-        double sat[3],vel[3]; calc_sat_position_velocity(ch[i].prn,usr.week,usr.sow,sat,vel);
+        double sat[3],vel[3];
+        calc_sat_position_velocity(ch[i].prn,usr.week,usr.sow,sat,vel);
         double dx=sat[0]-usr.xyz[0],dy=sat[1]-usr.xyz[1],dz=sat[2]-usr.xyz[2];
         double rho=hypot(hypot(dx,dy),dz);
         double rdot=(dx*(vel[0]-uvel[0]) + dy*(vel[1]-uvel[1]) + dz*(vel[2]-uvel[2]))/rho;
         update_channel_dynamics(&ch[i],rho,rdot,n_ch,cfg->gain);
-        printf("PRN%02d t=%.1fs rdot=%.2f fd=%.2fHz\n",
-               ch[i].prn, 0.0, rdot, ch[i].fd);
+        printf("[ch%02d] rdot %.2f fd %.2fHz\n", ch[i].prn, rdot, ch[i].fd);
     }
 
     FILE *fp=fopen("beidou_b1i.bin","wb"); if(!fp){perror("bin");return;}
@@ -166,8 +166,6 @@ void generate_signal(const sim_config_t *cfg)
             double rho=hypot(hypot(dx,dy),dz);
             double rdot=(dx*(vel[0]-uvel[0]) + dy*(vel[1]-uvel[1]) + dz*(vel[2]-uvel[2]))/rho;
             update_channel_dynamics(&ch[i],rho,rdot,n_ch,cfg->gain);
-            printf("PRN%02d t=%.1fs rdot=%.2f fd=%.2fHz\n",
-                   ch[i].prn, t_abs-start_bdt, rdot, ch[i].fd);
         }
 
         /* --- STEP_MS 次 1ms 取樣 --- */

--- a/main.c
+++ b/main.c
@@ -11,10 +11,15 @@
 /* ───────────────────────────── */
 static void usage(const char *p)
 {
-    puts("用法:");
-    printf("  %s --rinex nav.rnx --start YYYY/MM/DD,hh:mm:ss \n", p);
-    puts("     [--llh lat,lon,h] [--xyz file] [--llh-file file] [--nmea file]");
-    puts("     [--duration sec] [--gain amp]\n");
+    printf("用法: %s --rinex file --start YYYY/MM/DD,hh:mm:ss [選項]\n", p);
+    puts("選項:");
+    puts("  --llh lat,lon,h      固定使用者位置");
+    puts("  --xyz file           ECEF 路徑檔");
+    puts("  --llh-file file      LLH 路徑檔");
+    puts("  --nmea file          NMEA 路徑檔");
+    puts("  --duration sec       模擬秒數 (1-3600)");
+    puts("  --gain amp           輸出增益 (>0)");
+    puts("  --help               顯示本說明\n");
 }
 
 int main(int argc,char *argv[])
@@ -82,8 +87,12 @@ int main(int argc,char *argv[])
                 return 1;
             }
             break;
+        case 'h':
+            usage(argv[0]);
+            return 0;
         default:
-            usage(argv[0]); return 0;
+            usage(argv[0]);
+            return 1;
         }
     }
 
@@ -143,17 +152,16 @@ int main(int argc,char *argv[])
     int n_ch;
     select_channels(ch,&n_ch,&usr);
 
-    /* 印出確認訊息 */
-    printf("[cfg] UTC   : %s\n", cfg.time_start);
-    printf("[cfg] BDT   : week %d  sow %.3f\n", usr.week, usr.sow);
-    printf("[cfg] LLH   : %.6f, %.6f, %.1f\n",
+    /* 印出確認訊息 (簡潔模式) */
+    printf("[cfg] UTC %s  BDT W%d %.3f\n",
+           cfg.time_start, usr.week, usr.sow);
+    printf("[cfg] LLH %.6f %.6f %.1f\n",
            usr.llh[0], usr.llh[1], usr.llh[2]);
-    printf("[cfg] XYZ   : %.3f %.3f %.3f (m)\n",
+    printf("[cfg] XYZ %.3f %.3f %.3f (m)\n",
            usr.xyz[0], usr.xyz[1], usr.xyz[2]);
-    printf("[cfg] PRN   :");
+    printf("[cfg] PRN:");
     for(int i=0;i<n_ch;i++) printf(" %02d", ch[i].prn);
-    printf("\n[cfg] Gain  : %.2f\n", cfg.gain);
-    puts("");
+    printf("  Gain %.2f\n\n", cfg.gain);
 
     /* 4. 產生基帶 ----------------------------------- */
     generate_signal(&cfg);
@@ -161,7 +169,7 @@ int main(int argc,char *argv[])
 
     /* 5. 結束 --------------------------------------- */
     cleanup_simulator();
-    puts("👍 全部完成");
+    puts("[done] beidou_b1i.bin 已產生");
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- clarify command usage help text and add `--help` handling
- show concise configuration summary
- mention `--help` in README
- reduce verbose channel output

## Testing
- `make`
- `./bds-sim --help | head`
- `./bds-sim --rinex BRDM00DLR_S_20251760000_01D_MN.rnx --start 2025/06/25,00:00:00 --duration 1 --llh 0,0,0 --gain 1.0`


------
https://chatgpt.com/codex/tasks/task_e_6863c6dce1048327a554ce58333fedce