### PR TITLE
Improve B1I sample scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ may appear to contain only zeros or `-1` values.
           --llh lat,lon,height
 ```
 
-`--gain` scales the output amplitude. Values greater than 1 boost the
-signal level.
+`--gain` scales the output amplitude.  With the default gain of `1.0`
+the composite signal uses most of the 16‑bit range.  Larger values boost
+the level but may cause clipping.
 
 `--start` specifies the UTC start time; `--duration` is in seconds and
 `--llh` defines the user location in degrees and meters.

--- a/channel.c
+++ b/channel.c
@@ -34,7 +34,10 @@ static inline void fast_sincos(double ph,float*co,float*si){
 /* ---------- 振幅 ---------- */
 double calc_amp(double rho,int n_ch,double gain){
     double p = -130.0 - 20.0*log10(rho/2.0e7);
-    return gain * (float)pow(10.0,(p-DBM_REF)/20.0)/n_ch;
+    double a = pow(10.0,(p-DBM_REF)/20.0);    /* relative field amplitude */
+    /* Scale to 16‑bit output range. Each channel shares the range */
+    a *= 16384.0 / n_ch;
+    return gain * a;
 }
 
 /* ---------- CA cache ---------- */


### PR DESCRIPTION
## Summary
- scale channel amplitude to use 16‑bit range
- document default gain behaviour

## Testing
- `make`
- `./bds-sim --rinex BRDM00DLR_S_20251760000_01D_MN.rnx --start 2025/06/25,00:00:00 --duration 1 --llh 25,121,100 --gain 1.0`

------
https://chatgpt.com/codex/tasks/task_e_6863d5f368508327af38f71573cfdf88