### PR TITLE
Fix BPSK amplitude clipping

### DIFF
--- a/channel.c
+++ b/channel.c
@@ -9,7 +9,7 @@
 #define FCARRIER   1561.098e6      /* B1I */
 #define CHIPRATE   2.046e6
 #define FS         8.184e6
-#define DBM_REF   (-159.0)         /* ±1.0 → –159 dBm */
+#define DBM_REF   (-130.0)         /* ±1.0 → –130 dBm */
 
 /* ---------- 32k sin LUT ---------- */
 #define LUTBITS   15


### PR DESCRIPTION
## Summary
- prevent waveform clipping by adjusting the reference level used for amplitude calculations

## Testing
- `make bds-sim`
- `./bds-sim --rinex BRDM00DLR_S_20251760000_01D_MN.rnx --start 2025/06/25,00:00:00 --duration 1 --llh 0,0,0 --gain 1`

------
https://chatgpt.com/codex/tasks/task_e_6863e61a26a08327893fd7cddc24ee56