### PR TITLE
Fix B1I modulation by adding NH20 code

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ BDS‑SDRSIM parses BeiDou ephemeris from the RINEX navigation file,
 computes satellite positions and Doppler shifts for the requested start
 time and user location, and builds the B1I navigation subframes.  Each
 enabled satellite channel spreads these bits with the appropriate PRN
-code and the channels are summed to produce complex baseband samples.
+code.  The 50 bps D1 navigation message is further modulated by the
+standard 20‑bit Neumann–Hoffman sequence so that the resulting signal
+matches the BeiDou B1I specification.  Finally the channels are summed to
+produce complex baseband samples ready for SDR playback.
 The output is ready to be transmitted by an SDR.
 
 ## Detailed System Description

--- a/channel.c
+++ b/channel.c
@@ -44,6 +44,11 @@ double calc_amp(double rho,int n_ch,double gain){
 static int16_t ca_wave[64][CODE_LEN];
 static int     ca_ready=0;
 
+/* BeiDou D1 Neumann-Hoffman 20-bit code (0=+1, 1=-1) */
+static const uint8_t nh20_bits[20]={
+    0,0,0,0,0,1,0,0,1,1,0,1,0,1,0,0,1,1,1,0
+};
+
 /* ---------- Channel helpers ---------- */
 void channel_reset(channel_t *c,int prn){
     memset(c,0,sizeof(*c));
@@ -78,7 +83,8 @@ void gen_samples_1ms(channel_t *c,int week,double sow,int16_t*I,int16_t*Q)
     for(int n=0;n<SAMP_1MS;++n){
         int chip = (int)code_phase;            /* 0..2045 */
         int16_t ca = ca_wave[c->prn][chip];
-        int16_t nb = c->nav_bits[c->bit_ptr]?+1:-1;
+        uint8_t nh = nh20_bits[c->ms_count];
+        int16_t nb = (c->nav_bits[c->bit_ptr]^nh)?+1:-1;
         float co,si; fast_sincos(phase,&co,&si);
         float s = c->amp*ca*nb;
         I[n]=(int16_t)lrintf(s*co);


### PR DESCRIPTION
## Summary
- implement BeiDou NH20 sequence in channel modulation
- document Neumann–Hoffman usage in README

## Testing
- `make`
- `make prn_test`
- `./bds-sim --rinex BRDM00DLR_S_20251760000_01D_MN.rnx --start 2025/06/25,00:00:00 --duration 1 --llh 0,0,0`

------
https://chatgpt.com/codex/tasks/task_e_6864c588748c8327880779528c8d94b5