### PR TITLE
Reduce sample rate to 2.046 MHz

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ tool computes the user position (static or from a path file), derives
 satellite geometry and Doppler, and updates the channel state. The
 navigation message for subframes 1–5 is generated with correct
 time-of-week. Each channel spreads the bits with its PRN code and the
-samples are summed into a 16‑bit I/Q stream at 8.184 MHz.
+samples are summed into a 16‑bit I/Q stream at 2.046 MHz.
 
 ## Build
 
@@ -37,7 +37,7 @@ the first chips of PRN codes using the bundled RINEX file.
 
 The build produces `bds-sim` which outputs a signed `beidou_b1i.bin`
 file containing interleaved **16‑bit little‑endian** I/Q samples at
-8.184 MHz.  Each sample is a pair of 16‑bit integers `(I,Q)` so be
+2.046 MHz.  Each sample is a pair of 16‑bit integers `(I,Q)` so be
 careful not to interpret the file as 8‑bit data—otherwise the Q channel
 may appear to contain only zeros or `-1` values.
 
@@ -97,7 +97,7 @@ the simulation start.
 ## SDR playback
 
 The file `beidou_b1i.bin` contains interleaved **16‑bit little‑endian**
-I/Q samples at 8.184 MHz.  Ensure any analysis or playback software
+I/Q samples at 2.046 MHz.  Ensure any analysis or playback software
 reads the file as 16‑bit integers; using 8‑bit interpretation will yield
 Q samples that look like zeros.
 
@@ -107,7 +107,7 @@ this is typically **1561.098 MHz** – and play the samples at the same
 rate.  The following command illustrates playback with a HackRF:
 
 ```bash
-hackrf_transfer -t beidou_b1i.bin -f 1561098000 -s 8184000 -x 0
+hackrf_transfer -t beidou_b1i.bin -f 1561098000 -s 2046000 -x 0
 ```
 
 Use the `-R` option for continuous looping if needed.  Other SDRs can

--- a/bdssim.c
+++ b/bdssim.c
@@ -1,4 +1,4 @@
-/* bdssim.c : 8.184 Msps 北斗 B1I 基帶產生器 */
+/* bdssim.c : 2.046 Msps 北斗 B1I 基帶產生器 */
 #include <stdio.h>
 #include <string.h>
 #include <stdint.h>
@@ -13,8 +13,8 @@
 #include "path.h"
 #include "globals.h"     /* nav_week */
 #define OMEGA_E   7.2921150e-5
-#define FSAMP     8.184e6
-#define SAMP_1MS  8184
+#define FSAMP     2.046e6
+#define SAMP_1MS  2046
 
 static const int geo[] ={1,2,3,4,5,59,60,61,62,63};
 static int is_geo(int p){for(int i=0;i<10;i++) if(p==geo[i]) return 1; return 0;}

--- a/channel.c
+++ b/channel.c
@@ -8,7 +8,7 @@
 #define PI2        6.2831853071795864769
 #define FCARRIER   1561.098e6      /* B1I */
 #define CHIPRATE   2.046e6
-#define FS         8.184e6
+#define FS         2.046e6
 #define DBM_REF   (-130.0)         /* ±1.0 → –130 dBm */
 
 /* ---------- 32k sin LUT ---------- */

--- a/channel.h
+++ b/channel.h
@@ -5,7 +5,7 @@
 
 #define MAX_CH     12
 #define CODE_LEN   2046
-#define SAMP_1MS   8184
+#define SAMP_1MS   2046
 
 typedef struct {
     int     prn;

--- a/main.c
+++ b/main.c
@@ -26,7 +26,7 @@ int main(int argc,char *argv[])
 {
     /* 1. 預設參數 ----------------------------------- */
     sim_config_t cfg = {0};
-    cfg.sample_rate = 8184000;
+    cfg.sample_rate = 2046000;
     cfg.gain        = 1.0;
     cfg.step_ms     = 1;
     cfg.duration    = 300;                /* 預設 300 秒 */


### PR DESCRIPTION
## Summary
- lower sample rate constants to 2.046 Msps
- update default sample rate
- document new sampling rate in README

## Testing
- `make clean`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_6864ca870b288327ace4d35ed3474e47