### PR TITLE
Add configurable sample rate option

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ tool computes the user position (static or from a path file), derives
 satellite geometry and Doppler, and updates the channel state. The
 navigation message for subframes 1–5 is generated with correct
 time-of-week. Each channel spreads the bits with its PRN code and the
-samples are summed into a 16‑bit I/Q stream at 5 MHz.
+samples are summed into a 16‑bit I/Q stream at a configurable sample
+rate (default 5 MHz).
 
 ## Build
 
@@ -36,8 +37,9 @@ The optional command `make prn_test` builds a small utility that prints
 the first chips of PRN codes using the bundled RINEX file.
 
 The build produces `bds-sim` which outputs a signed `beidou_b1i.bin`
-file containing interleaved **16‑bit little‑endian** I/Q samples at
-5 MHz.  Each sample is a pair of 16‑bit integers `(I,Q)` so be
+file containing interleaved **16‑bit little‑endian** I/Q samples. By
+default the file is written at 5 MHz.  Each sample is a pair of
+16‑bit integers `(I,Q)` so be
 careful not to interpret the file as 8‑bit data—otherwise the Q channel
 may appear to contain only zeros or `-1` values.
 
@@ -47,6 +49,7 @@ may appear to contain only zeros or `-1` values.
 ./bds-sim --rinex BRDM00DLR_S_20251760000_01D_MN.rnx \
           --start 2025/06/25,00:00:00 \
           --duration 60 \
+          --srate 5000000 \
           --gain 1.0 \
           --llh lat,lon,height
 ```
@@ -54,6 +57,8 @@ may appear to contain only zeros or `-1` values.
 `--gain` scales the output amplitude.  With the default gain of `1.0`
 the composite signal uses most of the 16‑bit range.  Larger values boost
 the level but may cause clipping.
+
+`--srate` sets the I/Q sample rate in Hertz. The default is `5000000`.
 
 `--start` specifies the UTC start time; `--duration` is in seconds and
 `--llh` defines the user location in degrees and meters.
@@ -97,8 +102,9 @@ the simulation start.
 ## SDR playback
 
 The file `beidou_b1i.bin` contains interleaved **16‑bit little‑endian**
-I/Q samples at 5 MHz.  Ensure any analysis or playback software
-reads the file as 16‑bit integers; using 8‑bit interpretation will yield
+I/Q samples written at the configured sample rate (default 5 MHz).
+Ensure any analysis or playback software reads the file as 16‑bit
+integers; using 8‑bit interpretation will yield
 Q samples that look like zeros.
 
 The signal is at baseband (zero‑IF), so tune the

--- a/main.c
+++ b/main.c
@@ -19,6 +19,7 @@ static void usage(const char *p)
     puts("  --nmea file          NMEA 路徑檔");
     puts("  --duration sec       模擬秒數 (1-3600)");
     puts("  --gain amp           輸出增益 (>0)");
+    puts("  --srate Hz           取樣率 (Hz)");
     puts("  --help               顯示本說明\n");
 }
 
@@ -41,12 +42,13 @@ int main(int argc,char *argv[])
         {"nmea",     required_argument, 0, 'n'},
         {"duration", required_argument, 0, 'd'},
         {"gain",     required_argument, 0, 'g'},
+        {"srate",    required_argument, 0, 's'},
         {"help",     no_argument,       0, 'h'},
         {0,0,0,0}
     };
 
     int c, idx;
-    while((c = getopt_long(argc, argv, "e:t:l:x:y:n:d:g:h", longopt, &idx)) != -1){
+    while((c = getopt_long(argc, argv, "e:t:l:x:y:n:d:g:s:h", longopt, &idx)) != -1){
         switch(c){
         case 'e':
             strncpy(cfg.rinex_file, optarg, sizeof(cfg.rinex_file)-1);
@@ -84,6 +86,14 @@ int main(int argc,char *argv[])
             cfg.gain = atof(optarg);
             if(cfg.gain <= 0.0){
                 fprintf(stderr,"--gain 必須 >0\n");
+                return 1;
+            }
+            break;
+        case 's':
+            cfg.sample_rate = (uint32_t)atof(optarg);
+            if(cfg.sample_rate < 100000)
+            {
+                fprintf(stderr, "--srate 無效\n");
                 return 1;
             }
             break;
@@ -161,7 +171,8 @@ int main(int argc,char *argv[])
            usr.xyz[0], usr.xyz[1], usr.xyz[2]);
     printf("[cfg] PRN:");
     for(int i=0;i<n_ch;i++) printf(" %02d", ch[i].prn);
-    printf("  Gain %.2f\n\n", cfg.gain);
+    printf("  Fs %.1fMHz  Gain %.2f\n\n",
+           cfg.sample_rate/1e6, cfg.gain);
 
     /* 4. 產生基帶 ----------------------------------- */
     generate_signal(&cfg);


### PR DESCRIPTION
## Summary
- add `--srate` option in CLI to set output sample rate
- show sample rate in startup message
- document the option in README with updated usage example

## Testing
- `make`
- run `./bds-sim --rinex ... --srate 5000000`
- `make test_beidou`

------
https://chatgpt.com/codex/tasks/task_e_6864e98179c883279a9f7c96393b2406