### PR TITLE
Add byte output option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ default the file is written at 5 MHz.  Each sample is a pair of
 16‑bit integers `(I,Q)` so be
 careful not to interpret the file as 8‑bit data—otherwise the Q channel
 may appear to contain only zeros or `-1` values.
+Using the `--byte` flag additionally writes `beidou_b1i_u8.bin` with
+signed **8‑bit** samples for quick inspection.
 
 ## Usage
 
@@ -51,7 +53,8 @@ may appear to contain only zeros or `-1` values.
           --duration 60 \
           --srate 5000000 \
           --gain 1.0 \
-          --llh lat,lon,height
+          --llh lat,lon,height \
+          --byte
 ```
 
 `--gain` scales the output amplitude.  With the default gain of `1.0`
@@ -70,6 +73,7 @@ sample units).  The default is `0` (no noise).
 `--seed` specifies the random seed for noise generation. The default is `1`.
 
 `--srate` sets the I/Q sample rate in Hertz. The default is `5000000`.
+`--byte`  additionally saves an 8‑bit version of the baseband samples.
 
 `--start` specifies the UTC start time; `--duration` is in seconds and
 `--llh` defines the user location in degrees and meters.
@@ -117,6 +121,8 @@ I/Q samples written at the configured sample rate (default 5 MHz).
 Ensure any analysis or playback software reads the file as 16‑bit
 integers; using 8‑bit interpretation will yield
 Q samples that look like zeros.
+When `--byte` is used, the companion file `beidou_b1i_u8.bin` stores the
+same samples in signed 8‑bit format.
 
 The signal is at baseband (zero‑IF), so tune the
 SDR’s RF centre frequency to the desired transmit frequency – for B1I

--- a/bdssim.c
+++ b/bdssim.c
@@ -178,6 +178,11 @@ void generate_signal(const sim_config_t *cfg)
     channel_set_fs(fs);
 
     FILE *fp=fopen("beidou_b1i.bin","wb"); if(!fp){perror("bin");return;}
+    FILE *fp8=NULL;
+    if(cfg->byte_output){
+        fp8=fopen("beidou_b1i_u8.bin","wb");
+        if(!fp8){perror("u8"); fclose(fp); return;}
+    }
     int16_t tmpI[MAX_CH][samp_per_ms],tmpQ[MAX_CH][samp_per_ms];
     int32_t accI[samp_per_ms],accQ[samp_per_ms];
     double sumI=0.0,sumQ=0.0,sumI2=0.0,sumQ2=0.0;
@@ -227,6 +232,7 @@ void generate_signal(const sim_config_t *cfg)
 
             /* 限幅並打包成 I/Q (加入 AWGN) */
             int16_t iq[2*samp_per_ms];
+            int8_t  iq8[2*samp_per_ms];
             for(int k=0;k<samp_per_ms;++k){
                 int32_t i=accI[k];
                 int32_t q=accQ[k];
@@ -238,6 +244,8 @@ void generate_signal(const sim_config_t *cfg)
                 if(q>32767)q=32767; else if(q<-32768)q=-32768;
                 iq[2*k]   = (int16_t)i;
                 iq[2*k+1] = (int16_t)q;
+                iq8[2*k]  = (int8_t)(iq[2*k]/256);
+                iq8[2*k+1]= (int8_t)(iq[2*k+1]/256);
                 sumI  += iq[2*k];
                 sumQ  += iq[2*k+1];
                 sumI2 += (double)iq[2*k]*iq[2*k];
@@ -245,14 +253,16 @@ void generate_signal(const sim_config_t *cfg)
             }
             samp_cnt += samp_per_ms;
             fwrite(iq,sizeof(int16_t),2*samp_per_ms,fp);
+            if(fp8) fwrite(iq8,sizeof(int8_t),2*samp_per_ms,fp8);
 
         }
         /* 進度顯示 */
         printf("\r進度: %.2f / %.2f 秒",(ms+STEP_MS)/1000.0,total_ms/1000.0);
         fflush(stdout);
     }
-    puts(""); fclose(fp);
+    puts(""); fclose(fp); if(fp8) fclose(fp8);
     puts("[bdssim] 完成多星基帶輸出 beidou_b1i.bin");
+    if(fp8) puts("[bdssim] 完成多星基帶輸出 beidou_b1i_u8.bin");
     double meanI=sumI/samp_cnt, meanQ=sumQ/samp_cnt;
     double stdI = sqrt(sumI2/samp_cnt - meanI*meanI);
     double stdQ = sqrt(sumQ2/samp_cnt - meanQ*meanQ);

--- a/bdssim.h
+++ b/bdssim.h
@@ -46,6 +46,7 @@ typedef struct {
     double   gain;             /* 輸出增益 */
     double   noise_std;        /* AWGN 標準差 (0 表示無) */
     unsigned noise_seed;       /* AWGN 亂數種子 */
+    bool     byte_output;      /* 同時輸出 8-bit 檔 */
 } sim_config_t;
 
 /* ---------- 介面 ---------- */

--- a/main.c
+++ b/main.c
@@ -22,6 +22,7 @@ static void usage(const char *p)
     puts("  --noise stddev       加入 AWGN 雜訊標準差");
     puts("  --seed n            雜訊亂數種子 (整數)");
     puts("  --srate Hz           取樣率 (Hz)");
+    puts("  --byte               另輸出 8-bit 檔 beidou_b1i_u8.bin");
     puts("  --help               顯示本說明\n");
 }
 
@@ -35,6 +36,7 @@ int main(int argc,char *argv[])
     cfg.duration    = 300;                /* 預設 300 秒 */
     cfg.noise_std   = 0.0;
     cfg.noise_seed  = 1;
+    cfg.byte_output = false;
 
     /* 2. 解析 CLI ----------------------------------- */
     static struct option longopt[] = {
@@ -49,12 +51,13 @@ int main(int argc,char *argv[])
         {"noise",    required_argument, 0, 'z'},
         {"seed",     required_argument, 0, 'R'},
         {"srate",    required_argument, 0, 's'},
+        {"byte",     no_argument,       0, 'b'},
         {"help",     no_argument,       0, 'h'},
         {0,0,0,0}
     };
 
     int c, idx;
-    while((c = getopt_long(argc, argv, "e:t:l:x:y:n:d:g:z:R:s:h", longopt, &idx)) != -1){
+    while((c = getopt_long(argc, argv, "e:t:l:x:y:n:d:g:z:R:s:hb", longopt, &idx)) != -1){
         switch(c){
         case 'e':
             strncpy(cfg.rinex_file, optarg, sizeof(cfg.rinex_file)-1);
@@ -112,6 +115,9 @@ int main(int argc,char *argv[])
                 fprintf(stderr, "--srate 無效\n");
                 return 1;
             }
+            break;
+        case 'b':
+            cfg.byte_output = true;
             break;
         case 'h':
             usage(argv[0]);
@@ -197,6 +203,8 @@ int main(int argc,char *argv[])
     /* 5. 結束 --------------------------------------- */
     cleanup_simulator();
     puts("[done] beidou_b1i.bin 已產生");
+    if(cfg.byte_output)
+        puts("[done] beidou_b1i_u8.bin 已產生");
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- add `byte_output` flag to config
- implement writing 8‑bit samples to `beidou_b1i_u8.bin`
- expose `--byte` CLI option and document it

## Testing
- `make`
- `make prn_test`
- `./bds-sim --rinex BRDM00DLR_S_20251760000_01D_MN.rnx --start 2025/06/25,00:00:00 --duration 1 --llh 0,0,0 --byte --srate 1000000`

------
https://chatgpt.com/codex/tasks/task_e_6866450a5f9483278877a1b0673cf3fe