### PR TITLE
Add 25MHz rate when using --byte

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ default the file is written at 5 MHz.  Each sample is a pair of
 16‑bit integers `(I,Q)` so be
 careful not to interpret the file as 8‑bit data—otherwise the Q channel
 may appear to contain only zeros or `-1` values.
-Using the `--byte` flag additionally writes `beidou_b1i_u8.bin` with
-signed **8‑bit** samples for quick inspection.
+Using the `--byte` flag sets the sample rate to **25 MHz** and additionally
+writes `beidou_b1i_u8.bin` with signed **8‑bit** samples for quick
+inspection.
 The legacy option `-byte` is still recognised as an alias for `--byte`.
 
 ## Usage
@@ -74,7 +75,8 @@ sample units).  The default is `0` (no noise).
 `--seed` specifies the random seed for noise generation. The default is `1`.
 
 `--srate` sets the I/Q sample rate in Hertz. The default is `5000000`.
-`--byte`  additionally saves an 8‑bit version of the baseband samples.
+`--byte`  forces a 25 MHz sample rate and also saves an 8‑bit version of
+the baseband samples.
 
 `--start` specifies the UTC start time; `--duration` is in seconds and
 `--llh` defines the user location in degrees and meters. These static
@@ -124,8 +126,9 @@ I/Q samples written at the configured sample rate (default 5 MHz).
 Ensure any analysis or playback software reads the file as 16‑bit
 integers; using 8‑bit interpretation will yield
 Q samples that look like zeros.
-When `--byte` is used, the companion file `beidou_b1i_u8.bin` stores the
-same samples in signed 8‑bit format.
+When `--byte` is used, the sample rate is fixed to **25 MHz** and the
+companion file `beidou_b1i_u8.bin` stores the same samples in signed
+8‑bit format.
 
 The signal is at baseband (zero‑IF), so tune the
 SDR’s RF centre frequency to the desired transmit frequency – for B1I

--- a/main.c
+++ b/main.c
@@ -22,7 +22,7 @@ static void usage(const char *p)
     puts("  --noise stddev       加入 AWGN 雜訊標準差");
     puts("  --seed n            雜訊亂數種子 (整數)");
     puts("  --srate Hz           取樣率 (Hz)");
-    puts("  --byte               另輸出 8-bit 檔 beidou_b1i_u8.bin");
+    puts("  --byte               另輸出 8-bit 檔並將取樣率設為 25MHz");
     puts("  --help               顯示本說明\n");
 }
 
@@ -160,6 +160,9 @@ int main(int argc,char *argv[])
         fputs("--llh 超出合理範圍\n", stderr);
         return 1;
     }
+
+    if(cfg.byte_output)
+        cfg.sample_rate = 25000000;
 
     /* 3. 初始化 ------------------------------------- */
     if(!init_simulator(&cfg)){


### PR DESCRIPTION
## Summary
- support automatic 25 MHz sample rate when `--byte` flag is used
- document new `--byte` behaviour in README
- clarify help output

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_68664deda2b483278dcdd0bae223fbb2