### PR TITLE
Randomise channel start phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ range.
 
 `--noise` adds complex AWGN with the given standard deviation (in 16‑bit
 sample units).  The default is `0` (no noise).
-`--seed` specifies the random seed for noise generation. The default is `1`.
+`--seed` specifies the random seed for both noise generation and the
+initial carrier phase of each channel. The default is `1`.
 
 `--srate` sets the I/Q sample rate in Hertz. The default is `5000000`.
 `--byte`  forces a 25 MHz sample rate and saves only an 8‑bit version of

--- a/bdssim.c
+++ b/bdssim.c
@@ -141,8 +141,8 @@ void generate_signal(const sim_config_t *cfg)
 {
     coord_t usr={0};
     path_t path={0};
-    if(cfg->noise_std>0.0)
-        srand(cfg->noise_seed);
+    /* Initialise RNG for noise generation and random channel phase */
+    srand(cfg->noise_seed);
     if(cfg->path_type==1)       load_path_xyz(cfg->path_file,&path);
     else if(cfg->path_type==2)  load_path_llh(cfg->path_file,&path);
     else if(cfg->path_type==3)  load_path_nmea(cfg->path_file,&path);

--- a/channel.c
+++ b/channel.c
@@ -1,6 +1,7 @@
 /* channel.c : 單通道 1 ms B1I I/Q 產生 */
 #include <string.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <math.h>
 #include "channel.h"
 #include "globals.h"               /* prn_code */
@@ -89,6 +90,11 @@ void channel_reset(channel_t *c,int prn){
                 ca_wave[p][i] = prn_code[p][i]?+1:-1;
         ca_ready=1;
     }
+
+    /* Randomise starting carrier and code phase so I/Q averages
+       are well balanced even for short captures. */
+    c->carr_phase = ((double)rand()/(double)RAND_MAX)*PI2;
+    c->code_phase = ((double)rand()/(double)RAND_MAX)*CODE_LEN;
 }
 /* 幾何→計算振幅 / 初始多普勒 */
 void update_channel_dynamics(channel_t *c,double rho,double rdot,int n_ch,double gain){


### PR DESCRIPTION
## Summary
- randomise initial carrier/code phase for each channel so I/Q averages are well balanced
- seed RNG unconditionally for reproducible phase randomisation
- document new behaviour in README

## Testing
- `make bds-sim`
- `make prn_test`
- `./bds-sim --rinex BRDM00DLR_S_20251760000_01D_MN.rnx --start 2025/06/25,00:00:00 --duration 1 --srate 1000000 --gain 1.0 --llh 0,0,0`

------
https://chatgpt.com/codex/tasks/task_e_6866648f83f88327b5e41800d10ff9d3