### PR TITLE
Randomise channel start phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ default the file is written at 5 MHz.  Each sample is a pair of
 16‑bit integers `(I,Q)` so be
 careful not to interpret the file as 8‑bit data—otherwise the Q channel
 may appear to contain only zeros or `-1` values.
-Using the `--byte` flag sets the sample rate to **25 MHz** and writes only
-`beidou_b1i_u8.bin` containing signed **8‑bit** samples for quick
+Using the `--byte` flag sets the sample rate to **25 MHz** and writes
+`beidou_b1i_u8.bin` containing the **8‑bit** I channel only for quick
 inspection.
 The legacy option `-byte` is still recognised as an alias for `--byte`.
 
@@ -72,11 +72,12 @@ range.
 
 `--noise` adds complex AWGN with the given standard deviation (in 16‑bit
 sample units).  The default is `0` (no noise).
-`--seed` specifies the random seed for noise generation. The default is `1`.
+`--seed` specifies the random seed for both noise generation and the
+initial carrier phase of each channel. The default is `1`.
 
 `--srate` sets the I/Q sample rate in Hertz. The default is `5000000`.
-`--byte`  forces a 25 MHz sample rate and saves only an 8‑bit version of
-the baseband samples.
+`--byte`  forces a 25 MHz sample rate and saves an 8‑bit file containing
+only the I samples.
 
 `--start` specifies the UTC start time; `--duration` is in seconds and
 `--llh` defines the user location in degrees and meters. These static
@@ -127,8 +128,8 @@ Ensure any analysis or playback software reads the file as 16‑bit
 integers; using 8‑bit interpretation will yield
 Q samples that look like zeros.
 When `--byte` is used, the sample rate is fixed to **25 MHz** and the
-output file `beidou_b1i_u8.bin` stores the samples in signed
-8‑bit format only.
+output file `beidou_b1i_u8.bin` stores only the I samples in signed
+8‑bit format.
 
 The signal is at baseband (zero‑IF), so tune the
 SDR’s RF centre frequency to the desired transmit frequency – for B1I

--- a/bdssim.c
+++ b/bdssim.c
@@ -141,8 +141,8 @@ void generate_signal(const sim_config_t *cfg)
 {
     coord_t usr={0};
     path_t path={0};
-    if(cfg->noise_std>0.0)
-        srand(cfg->noise_seed);
+    /* Initialise RNG for noise generation and random channel phase */
+    srand(cfg->noise_seed);
     if(cfg->path_type==1)       load_path_xyz(cfg->path_file,&path);
     else if(cfg->path_type==2)  load_path_llh(cfg->path_file,&path);
     else if(cfg->path_type==3)  load_path_nmea(cfg->path_file,&path);
@@ -234,7 +234,7 @@ void generate_signal(const sim_config_t *cfg)
 
             /* 限幅並打包成 I/Q (加入 AWGN) */
             int16_t iq[2*samp_per_ms];
-            int8_t  iq8[2*samp_per_ms];
+            int8_t  i8[samp_per_ms];            /* byte output holds I only */
             for(int k=0;k<samp_per_ms;++k){
                 int32_t i=accI[k];
                 int32_t q=accQ[k];
@@ -246,8 +246,7 @@ void generate_signal(const sim_config_t *cfg)
                 if(q>32767)q=32767; else if(q<-32768)q=-32768;
                 iq[2*k]   = (int16_t)i;
                 iq[2*k+1] = (int16_t)q;
-                iq8[2*k]  = (int8_t)(iq[2*k]/256);
-                iq8[2*k+1]= (int8_t)(iq[2*k+1]/256);
+                i8[k]     = (int8_t)(iq[2*k]/256);
                 sumI  += iq[2*k];
                 sumQ  += iq[2*k+1];
                 sumI2 += (double)iq[2*k]*iq[2*k];
@@ -257,7 +256,7 @@ void generate_signal(const sim_config_t *cfg)
             if(fp)
                 fwrite(iq,sizeof(int16_t),2*samp_per_ms,fp);
             else
-                fwrite(iq8,sizeof(int8_t),2*samp_per_ms,fp8);
+                fwrite(i8,sizeof(int8_t),samp_per_ms,fp8);
 
         }
         /* 進度顯示 */

--- a/channel.c
+++ b/channel.c
@@ -1,6 +1,7 @@
 /* channel.c : 單通道 1 ms B1I I/Q 產生 */
 #include <string.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <math.h>
 #include "channel.h"
 #include "globals.h"               /* prn_code */
@@ -89,6 +90,11 @@ void channel_reset(channel_t *c,int prn){
                 ca_wave[p][i] = prn_code[p][i]?+1:-1;
         ca_ready=1;
     }
+
+    /* Randomise starting carrier and code phase so I/Q averages
+       are well balanced even for short captures. */
+    c->carr_phase = ((double)rand()/(double)RAND_MAX)*PI2;
+    c->code_phase = ((double)rand()/(double)RAND_MAX)*CODE_LEN;
 }
 /* 幾何→計算振幅 / 初始多普勒 */
 void update_channel_dynamics(channel_t *c,double rho,double rdot,int n_ch,double gain){

--- a/main.c
+++ b/main.c
@@ -22,7 +22,7 @@ static void usage(const char *p)
     puts("  --noise stddev       加入 AWGN 雜訊標準差");
     puts("  --seed n            雜訊亂數種子 (整數)");
     puts("  --srate Hz           取樣率 (Hz)");
-    puts("  --byte               25MHz 取樣率並以 8-bit 檔輸出");
+    puts("  --byte               25MHz 取樣率並僅輸出 I 之 8-bit 檔");
     puts("  --help               顯示本說明\n");
 }
 


### PR DESCRIPTION
## Summary
- randomise initial carrier/code phase for each channel so I/Q averages are well balanced
- seed RNG unconditionally for reproducible phase randomisation
- document new behaviour in README
- byte output stores only I samples

## Testing
- `make bds-sim`
- `make prn_test`
- `./bds-sim --rinex BRDM00DLR_S_20251760000_01D_MN.rnx --start 2025/06/25,00:00:00 --duration 1 --srate 1000000 --gain 1.0 --llh 0,0,0 --byte`
- `./bds-sim --rinex BRDM00DLR_S_20251760000_01D_MN.rnx --start 2025/06/25,00:00:00 --duration 1 --srate 1000000 --gain 1.0 --llh 0,0,0`


------
https://chatgpt.com/codex/tasks/task_e_6866648f83f88327b5e41800d10ff9d3