### PR TITLE
Update default sample rate to 6.144 MSps

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ satellite geometry and Doppler, and updates the channel state. The
 navigation message for subframes 1–5 is generated with correct
 time-of-week. Each channel spreads the bits with its PRN code and the
 samples are summed into a 16‑bit I/Q stream at a configurable sample
-rate (default 5 MHz).
+rate (default 6.144 MHz).
 
 ## Build
 
@@ -38,7 +38,7 @@ the first chips of PRN codes using the bundled RINEX file.
 
 The build produces `bds-sim` which outputs a signed `beidou_b1i.bin`
 file containing interleaved **16‑bit little‑endian** I/Q samples. By
-default the file is written at 5 MHz.  Each sample is a pair of
+default the file is written at 6.144 MHz.  Each sample is a pair of
 16‑bit integers `(I,Q)` so be
 careful not to interpret the file as 8‑bit data—otherwise the Q channel
 may appear to contain only zeros or `-1` values.
@@ -53,7 +53,7 @@ The legacy option `-byte` is still recognised as an alias for `--byte`.
 ./bds-sim --rinex BRDM00DLR_S_20251760000_01D_MN.rnx \
           --start 2025/06/25,00:00:00 \
           --duration 60 \
-          --srate 5000000 \
+          --srate 6144000 \
           --gain 1.0 \
           --llh lat,lon,height \
           --byte
@@ -75,7 +75,7 @@ sample units).  The default is `0` (no noise).
 `--seed` specifies the random seed for both noise generation and the
 initial carrier phase of each channel. The default is `1`.
 
-`--srate` sets the I/Q sample rate in Hertz. The default is `5000000`.
+`--srate` sets the I/Q sample rate in Hertz. The default is `6144000`.
 `--byte`  forces a 25 MHz sample rate and saves an 8‑bit file containing
 only the I samples.
 
@@ -123,7 +123,7 @@ the simulation start.
 ## SDR playback
 
 The file `beidou_b1i.bin` contains interleaved **16‑bit little‑endian**
-I/Q samples written at the configured sample rate (default 5 MHz).
+I/Q samples written at the configured sample rate (default 6.144 MHz).
 Ensure any analysis or playback software reads the file as 16‑bit
 integers; using 8‑bit interpretation will yield
 Q samples that look like zeros.
@@ -137,7 +137,7 @@ this is typically **1561.098 MHz** – and play the samples at the same
 rate.  The following command illustrates playback with a HackRF:
 
 ```bash
-hackrf_transfer -t beidou_b1i.bin -f 1561098000 -s 5000000 -x 0
+hackrf_transfer -t beidou_b1i.bin -f 1561098000 -s 6144000 -x 0
 ```
 
 Use the `-R` option for continuous looping if needed.  Other SDRs can

--- a/bdssim.c
+++ b/bdssim.c
@@ -14,7 +14,7 @@
 #include "path.h"
 #include "globals.h"     /* nav_week */
 #define OMEGA_E   7.2921150e-5
-#define FSAMP_DEF 5.0e6
+#define FSAMP_DEF 6.144e6
 
 static const int geo[] ={1,2,3,4,5,59,60,61,62,63};
 static int is_geo(int p){for(int i=0;i<10;i++) if(p==geo[i]) return 1; return 0;}

--- a/main.c
+++ b/main.c
@@ -30,7 +30,8 @@ int main(int argc,char *argv[])
 {
     /* 1. 預設參數 ----------------------------------- */
     sim_config_t cfg = {0};
-    cfg.sample_rate = 5000000;
+    /* default sample rate tuned for AD9361 clean clocking (6.144 MSps) */
+    cfg.sample_rate = 6144000;
     cfg.gain        = 1.0;
     cfg.step_ms     = 1;
     cfg.duration    = 300;                /* 預設 300 秒 */


### PR DESCRIPTION
## Summary
- set default sample rate to 6.144 MSps for AD9361 clocking
- reflect new rate in README examples and docs

## Testing
- `make`
- `make prn_test`


------
https://chatgpt.com/codex/tasks/task_e_68675edafdcc83278bfc0968fa2622ca