### PR TITLE
Improve PRN and navframe unit tests

### DIFF
--- a/tests/run_all.c
+++ b/tests/run_all.c
@@ -20,6 +20,8 @@ void test_full_word(void);
 void test_subframe1_sync(void);
 void test_subframe1_repeat(void);
 void test_subframe_bits_length(void);
+void test_subframe1_dummy_zero(void);
+void test_subframe1_parity(void);
 
 void test_chipseq_length_advances(void);
 void test_navbit_inversion(void);
@@ -46,6 +48,8 @@ int main(void)
     RUN_TEST(test_subframe1_sync);
     RUN_TEST(test_subframe1_repeat);
     RUN_TEST(test_subframe_bits_length);
+    RUN_TEST(test_subframe1_dummy_zero);
+    RUN_TEST(test_subframe1_parity);
 
     RUN_TEST(test_chipseq_length_advances);
     RUN_TEST(test_navbit_inversion);

--- a/tests/test_navframe.c
+++ b/tests/test_navframe.c
@@ -1,6 +1,7 @@
 #include "unity.h"
 #include "helpers.h"
 #include "navbits.h"
+#include "bch.h"
 #include <string.h>
 
 
@@ -17,6 +18,7 @@ void test_subframe1_sync(void)
 
 void test_subframe1_repeat(void)
 {
+    navbits_init();
     uint8_t bits[SUBFRAME_BITS];
     get_subframe_bits(1,1,0,0,bits);
     TEST_ASSERT_EQUAL_UINT8_ARRAY(bits, bits+HALF_SUBFRAME_BITS, HALF_SUBFRAME_BITS);
@@ -24,6 +26,7 @@ void test_subframe1_repeat(void)
 
 void test_subframe_bits_length(void)
 {
+    navbits_init();
     uint8_t bits[SUBFRAME_BITS];
     memset(bits,0xAA,sizeof(bits));
     get_subframe_bits(1,2,0,0,bits);
@@ -34,4 +37,29 @@ void test_subframe_bits_length(void)
         count++; /* every element should be filled */
     }
     TEST_ASSERT_EQUAL_INT(300, count);
+}
+
+void test_subframe1_dummy_zero(void)
+{
+    navbits_init();
+    uint8_t bits[SUBFRAME_BITS];
+    get_subframe_bits(1,1,0,0,bits);
+    for(int i=SUBFRAME_BITS-6;i<SUBFRAME_BITS;i++)
+        TEST_ASSERT_EQUAL_UINT8(0,bits[i]);
+}
+
+void test_subframe1_parity(void)
+{
+    navbits_init();
+    uint8_t bits[SUBFRAME_BITS];
+    get_subframe_bits(1,1,0,0,bits);
+    for(int w=0; w<SUBFRAME_BITS/30; w++){
+        uint32_t info=0; uint16_t enc=0;
+        for(int i=0;i<15;i++){
+            info = (info<<1) | bits[w*30 + 2*i];
+            enc  |= bits[w*30 + 2*i + 1] << i;
+        }
+        uint16_t expect = bch_encode(info) & ~0x8;
+        TEST_ASSERT_EQUAL_HEX16(expect, enc);
+    }
 }

--- a/tests/test_prn.c
+++ b/tests/test_prn.c
@@ -63,5 +63,5 @@ void test_prn_crosscorr(void)
         }
         if(abs(sum) > max) max = abs(sum);
     }
-    TEST_ASSERT_LESS_OR_EQUAL_INT(162, max);
+    TEST_ASSERT_LESS_OR_EQUAL_INT(160, max);
 }


### PR DESCRIPTION
## Summary
- tighten PRN cross-correlation limit
- expand navframe tests for dummy bits and BCH parity
- register new tests in `run_all.c`

## Testing
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_686b42bc181c8327b27bb5e35e6da43f