### PR TITLE
Improve GNSS unit tests

### DIFF
--- a/tests/run_all.c
+++ b/tests/run_all.c
@@ -6,10 +6,13 @@
 void test_prn_sequence(void);
 void test_prn_autocorr(void);
 void test_prn_crosscorr(void);
+void test_prn_crosscorr_known_lags(void);
+void test_prn_autocorr_known_lags(void);
 
 void test_zero_word(void);
 void test_one_word(void);
 void test_full_word(void);
+void test_random_word(void);
 
 void test_subframe1_sync(void);
 void test_subframe1_repeat(void);
@@ -22,6 +25,7 @@ void test_navbit_inversion(void);
 void test_bitptr_after_20ms(void);
 
 void test_amplitude_and_interleave(void);
+void test_q_branch_zero(void);
 void test_dc_offset(void);
 
 void test_fft_dc(void);
@@ -34,10 +38,13 @@ int main(void)
     RUN_TEST(test_prn_sequence);
     RUN_TEST(test_prn_autocorr);
     RUN_TEST(test_prn_crosscorr);
+    RUN_TEST(test_prn_crosscorr_known_lags);
+    RUN_TEST(test_prn_autocorr_known_lags);
 
     RUN_TEST(test_zero_word);
     RUN_TEST(test_one_word);
     RUN_TEST(test_full_word);
+    RUN_TEST(test_random_word);
 
     RUN_TEST(test_subframe1_sync);
     RUN_TEST(test_subframe1_repeat);
@@ -50,6 +57,7 @@ int main(void)
     RUN_TEST(test_bitptr_after_20ms);
 
     RUN_TEST(test_amplitude_and_interleave);
+    RUN_TEST(test_q_branch_zero);
     RUN_TEST(test_dc_offset);
 
     RUN_TEST(test_fft_dc);

--- a/tests/test_crc.c
+++ b/tests/test_crc.c
@@ -20,3 +20,10 @@ void test_full_word(void)
     TEST_ASSERT_EQUAL_HEX32(0xbfff7f74, w);
 }
 
+/* Additional regression test for CRC implementation */
+void test_random_word(void)
+{
+    uint32_t w = hamming_parity(0x123456);
+    TEST_ASSERT_EQUAL_HEX32(0x82464532, w);
+}
+

--- a/tests/test_prn.c
+++ b/tests/test_prn.c
@@ -6,9 +6,8 @@
 
 void setUp(void)
 {
+    /* Ensure the full PRN table is generated once before each test */
     ensure_prn();
-    generate_prn(1, prn_code[1], CODE_LEN);
-    generate_prn(2, prn_code[2], CODE_LEN);
 }
 
 void tearDown(void){}
@@ -73,4 +72,34 @@ void test_prn_crosscorr(void)
         if(abs(sum) > max) max = abs(sum);
     }
     TEST_ASSERT_LESS_OR_EQUAL_INT(160, max);
+}
+
+/* Specific lag values for cross-correlation between PRN1 and PRN2.
+ * These serve as a regression check against accidental changes to the
+ * G2 tap table.  Values are derived from the current implementation. */
+void test_prn_crosscorr_known_lags(void)
+{
+    const int expect[6] = { -66,-42,-26,2,-26,-26 };
+    for(int lag=0; lag<6; lag++){
+        int sum=0;
+        for(int i=0;i<CODE_LEN;i++){
+            int j=(i+lag)%CODE_LEN;
+            sum += chip_val(prn_code[1][i])*chip_val(prn_code[2][j]);
+        }
+        TEST_ASSERT_EQUAL_INT(expect[lag], sum);
+    }
+}
+
+/* Check a few sidelobe values of PRN1 autocorrelation. */
+void test_prn_autocorr_known_lags(void)
+{
+    const int expect[5] = { 22,26,-70,-42,-10 };
+    for(int lag=1; lag<=5; lag++){
+        int sum=0;
+        for(int i=0;i<CODE_LEN;i++){
+            int j=(i+lag)%CODE_LEN;
+            sum += chip_val(prn_code[1][i])*chip_val(prn_code[1][j]);
+        }
+        TEST_ASSERT_EQUAL_INT(expect[lag-1], sum);
+    }
 }

--- a/tests/test_scaling.c
+++ b/tests/test_scaling.c
@@ -29,6 +29,17 @@ void test_amplitude_and_interleave(void)
     TEST_ASSERT_EQUAL_INT16(0,Q[0]);
 }
 
+/* With zero carrier offset the Q branch should remain zero for all
+ * samples.  Swapping the I/Q calculation would break this invariant. */
+void test_q_branch_zero(void)
+{
+    channel_t c; setup_ch(&c);
+    int16_t I[CODE_LEN],Q[CODE_LEN];
+    gen_samples_1ms(&c,0,0,CODE_LEN,I,Q);
+    for(int i=0;i<CODE_LEN;i++)
+        TEST_ASSERT_EQUAL_INT16(0,Q[i]);
+}
+
 void test_dc_offset(void)
 {
     channel_t c; setup_ch(&c);


### PR DESCRIPTION
## Summary
- ensure PRN table initialised by `setUp`
- add regression checks for PRN autocorrelation and cross‑correlation
- extend CRC tests with random pattern
- verify Q branch stays zero when no carrier offset
- register new tests in `run_all`

## Testing
- `make check`
- manual failure check by modifying `globals.c` (expect failures)

------
https://chatgpt.com/codex/tasks/task_e_686b5d864b3083278326e483c21ce2cf