### PR TITLE
Add CI workflow with fault injection and coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential lcov
+      - name: Normal Tests
+        run: make check
+      - name: Tap Fault Injection
+        run: tests/ci/fault_inject.sh tap
+      - name: CRC Fault Injection
+        run: tests/ci/fault_inject.sh crc
+      - name: Restore Source
+        run: git checkout -- .
+      - name: Tests After Restore
+        run: make check
+      - name: Generate Coverage
+        run: make coverage
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage
+          path: |
+            coverage-html
+            tests/ci/*.log
+

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,15 @@ clean:
 
 check:
 	$(MAKE) -C tests all && ./tests/run_all
-
+		
+coverage:
+	$(MAKE) clean
+	$(MAKE) -C tests clean
+	$(MAKE) -C tests CFLAGS="$(CFLAGS) -I.. -Iunity -Iext/kissfft --coverage -O0" all
+	./tests/run_all
+	lcov -c -d . -o coverage.info
+	genhtml coverage.info -o coverage-html
+	
 # =====================[ 下載區 ]=====================
 # 使用範例：
 #   make download-brdm20251760          (下載 2025/176 BRDM)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,5 +1,5 @@
 CC=gcc
-CFLAGS=-I.. -Iunity -Iext/kissfft -O2 -Wall
+CFLAGS?=-I.. -Iunity -Iext/kissfft -O2 -Wall
 
 TESTS= test_prn.o test_crc.o test_navframe.o test_chipseq.o        test_scaling.o test_fft.o helpers.o unity/unity.o        ext/kissfft/kiss_fft.o
 PROJ= ../globals.o ../bch.o ../navbits.o ../channel.o ../rinex.o       ../orbits.o ../coord.o ../path.o ../bdssim.o

--- a/tests/ci/fault_inject.sh
+++ b/tests/ci/fault_inject.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -e
+MODE="$1"
+LOG="tests/ci/${MODE}.log"
+case "$MODE" in
+  tap)
+    sed -i 's/{ 1, 3, 0}/{ 1, 4, 0}/' globals.c
+    ;;
+  crc)
+    perl -0pi -e 's/overall \^= __builtin_parity\(word & ~\(1u<<\(32-1\)\)\);/overall ^= __builtin_parity(word & ~(1u<<(32-1))) ^ 0x01;/' tests/helpers.c
+    ;;
+  *)
+    echo "Usage: $0 tap|crc" >&2
+    exit 1
+    ;;
+esac
+if make check > "$LOG" 2>&1; then
+  cat "$LOG"
+  echo "Unexpected pass" >&2
+  exit 1
+else
+  cat "$LOG"
+  exit 0
+fi


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run tests, fault injection steps, and coverage
- provide script to inject faults for PRN taps and CRC logic
- update Makefile with new `coverage` target
- allow overriding of test CFLAGS for coverage builds

## Testing
- `make check`
- `make coverage` *(fails: lcov not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686b632bc92c8327910039c31744a59e