### PR TITLE
Fix coverage rule and CI lcov install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential lcov
+      - name: Install lcov
+        run: sudo apt-get update && sudo apt-get install -y lcov
       - name: Normal Tests
         run: make check
       - name: Tap Fault Injection

--- a/Makefile
+++ b/Makefile
@@ -22,13 +22,14 @@ check:
 	$(MAKE) -C tests all && ./tests/run_all
 		
 coverage:
+	@command -v lcov >/dev/null 2>&1 || { echo "lcov or genhtml not installed"; exit 1; }
+	@command -v genhtml >/dev/null 2>&1 || { echo "lcov or genhtml not installed"; exit 1; }
 	$(MAKE) clean
 	$(MAKE) -C tests clean
-	$(MAKE) -C tests CFLAGS="$(CFLAGS) -I.. -Iunity -Iext/kissfft --coverage -O0" all
+	$(MAKE) -C tests coverage CFLAGS="$(CFLAGS) -I.. -Iunity -Iext/kissfft"
 	./tests/run_all
 	lcov -c -d . -o coverage.info
 	genhtml coverage.info -o coverage-html
-	
 # =====================[ 下載區 ]=====================
 # 使用範例：
 #   make download-brdm20251760          (下載 2025/176 BRDM)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -18,4 +18,7 @@ run_all: $(TESTS) run_all.o $(PROJ)
 clean:
 	rm -f *.o run_all ../*.o
 
-.PHONY: all clean
+coverage:
+	$(MAKE) CFLAGS+="--coverage -O0" all
+
+.PHONY: all clean coverage


### PR DESCRIPTION
## Summary
- install `lcov` before running Makefile in CI
- update coverage rule to verify lcov/genhtml presence and call new tests coverage target
- add coverage target in `tests/Makefile`

## Testing
- `make coverage`
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_686b65b360ec8327af284ed0cb581987