### PR TITLE
Use CI Docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,14 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: ghcr.io/<YOUR_ORG>/beidou-ci:latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Normal Tests
+        run: make check

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,3 @@
+FROM ubuntu:22.04
+RUN apt-get update && apt-get install -y build-essential lcov git && \
+    rm -rf /var/lib/apt/lists/*

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,16 @@
+# CI Docker Image
+
+The CI workflow uses a prebuilt Docker image hosted on GitHub Container Registry.
+
+## Build and Push
+
+```bash
+# build the image
+docker build -t ghcr.io/<YOUR_ORG>/beidou-ci:latest -f docker/Dockerfile .
+
+# login to GHCR (requires a token with write:packages)
+echo "$GHCR_TOKEN" | docker login ghcr.io -u <YOUR_ORG> --password-stdin
+
+# push the image
+docker push ghcr.io/<YOUR_ORG>/beidou-ci:latest
+```


### PR DESCRIPTION
## Summary
- add Dockerfile for CI image
- run CI in `ghcr.io/<YOUR_ORG>/beidou-ci:latest`
- document how to rebuild and push the image

## Testing
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_686b67a007188327bf76e446fa2ce5b2