### PR TITLE
Fix D2 generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Added subframe 4/5 template
 * Default Fs → 8.192 MHz
 * Power scaling by target CN₀
-* Basic D2 (1 kbps) support with D1 interleaving
+* Basic D2 (500 bps) support with D1 interleaving
 
 ## v0.3.1 (unreleased)
 * Subframe 4/5 words set to official 0xAAAAAAAA pattern

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ time and user location, and builds the B1I navigation subframes.  Each
 enabled satellite channel spreads these bits with the appropriate PRN
 code.  The 50 bps D1 navigation message is further modulated by the
 standard 20‑bit Neumann–Hoffman sequence so that the resulting signal
-matches the BeiDou B1I specification.  Optionally a 1 kbps D2 message
-using a 10‑bit Neumann–Hoffman overlay can be interleaved every other
-millisecond.  Finally the channels are summed to
+matches the BeiDou B1I specification.  Optionally a 500 bps D2 message
+without secondary coding and can be interleaved every other millisecond.
+Finally the channels are summed to
 produce complex baseband samples ready for SDR playback.
 The output is ready to be transmitted by an SDR.
 
@@ -164,7 +164,7 @@ searches for the correct PRNs automatically.
 * Added subframe 4/5 template
 * Default Fs → 8.192 MHz
 * Power scaling by target CN₀
-* Basic D2 (1 kbps) support with D1 interleaving
+* Basic D2 (500 bps) support with D1 interleaving
 
 ## v0.3.1 (unreleased)
 * Correct subframe 4/5 constant words

--- a/channel.c
+++ b/channel.c
@@ -81,10 +81,6 @@ static const uint8_t nh20_bits[20]={
     0,0,0,0,0,1,0,0,1,1,0,1,0,1,0,0,1,1,1,0
 };
 
-/* BeiDou D2 Neumann-Hoffman 10-bit code (0=+1, 1=-1) */
-static const uint8_t nh10_bits[10]={
-    0,0,0,1,1,0,1,1,1,0
-};
 
 /* ---------- Channel helpers ---------- */
 void channel_reset(channel_t *c,int prn){
@@ -165,8 +161,9 @@ void gen_samples_1ms(channel_t *c,int week,double sow,
 }
 
 /*
- * ======== D2 (1 kbps) support ========
- *  - 資料速率 1 kbps，Neumann-Hoffman 10-bit overlay
+ * ======== D2 (500 bps) support ========
+ *  - 資料速率 500 bps (2 ms per bit)
+ *  - 不使用二次 Neumann-Hoffman 編碼
  *  - 與 D1 交錯：偶數毫秒 Tx D2，奇數毫秒 Tx D1
  */
 void gen_samples_1ms_d2(channel_t *c, int week, double sow,
@@ -183,8 +180,7 @@ void gen_samples_1ms_d2(channel_t *c, int week, double sow,
     for(int n=0;n<samp_per_ms;++n){
         int chip = (int)code_phase;
         int16_t ca = ca_wave[c->prn][chip];
-        uint8_t nh = nh10_bits[c->ms_count_d2];
-        int16_t nb = (c->nav_bits_d2[c->bit_ptr_d2]^nh)?+1:-1;
+        int16_t nb = c->nav_bits_d2[c->bit_ptr_d2] ? -1:+1;
         float co,si; fast_sincos(phase,&co,&si);
         float s = c->amp*ca*nb;
         I[n]=(int16_t)lrintf(s*co);
@@ -201,7 +197,7 @@ void gen_samples_1ms_d2(channel_t *c, int week, double sow,
     c->carr_phase = phase;
     c->code_phase = code_phase;
 
-    if(++c->ms_count_d2==10){
+    if(++c->ms_count_d2==2){
         c->ms_count_d2=0;
         if(++c->bit_ptr_d2==300){
             c->bit_ptr_d2=0;


### PR DESCRIPTION
## Summary
- add a real D2 mode at 500 bps without NH overlay
- update README and CHANGELOG accordingly

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_686b9553ec7c8327a897c8271aee7a7c