### PR TITLE
Update sample rate parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The legacy option `-byte` is still recognised as an alias for `--byte`.
 ./bds-sim --rinex BRDM00DLR_S_20251760000_01D_MN.rnx \
           --start 2025/06/25,00:00:00 \
           --duration 60 \
-          --srate 8192000 \
+          --srate 8 \
           --gain 1.0 \
           --llh lat,lon,height \
           --byte
@@ -79,7 +79,9 @@ sample units).  The default is `0` (no noise).
 `--seed` specifies the random seed for both noise generation and the
 initial carrier phase of each channel. The default is `1`.
 
-`--srate` sets the I/Q sample rate in Hertz. The default is `8192000`.
+`--srate` sets the I/Q sample rate in Hertz. Values `2`, `4` and `8`
+select the common 2.048, 4.096 and 8.192 MHz rates respectively. The
+default is `8192000`.
 `--byte`  forces a 25 MHz sample rate and saves an 8‑bit file containing
 only the I samples.
 

--- a/main.c
+++ b/main.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <getopt.h>
+#include <math.h>
 
 #include "bdssim.h"
 #include "timeconv.h"
@@ -120,14 +121,22 @@ int main(int argc,char *argv[])
         case 'R':
             cfg.noise_seed = (unsigned)strtoul(optarg,NULL,0);
             break;
-        case 's':
-            cfg.sample_rate = (uint32_t)atof(optarg);
-            if(cfg.sample_rate < 100000)
-            {
+        case 's': {
+            double val = atof(optarg);
+            if(val>0 && val<1000){
+                if(fabs(val-2.0)<0.2)      cfg.sample_rate = 2048000;
+                else if(fabs(val-4.0)<0.2) cfg.sample_rate = 4096000;
+                else if(fabs(val-8.0)<0.2) cfg.sample_rate = 8192000;
+                else                       cfg.sample_rate = (uint32_t)(val*1e6+0.5);
+            }else{
+                cfg.sample_rate = (uint32_t)val;
+            }
+            if(cfg.sample_rate < 100000){
                 fprintf(stderr, "--srate 無效\n");
                 return 1;
             }
             break;
+        }
         case 'b':
             cfg.byte_output = true;
             break;


### PR DESCRIPTION
## Summary
- handle `--srate` values of `2`, `4` and `8` as MHz presets
- document the new shorthand in the README

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_686ba3d5f8e08327aaa14160f74ce750