### PR TITLE
Change default sample rate to 5.120 MHz

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ satellite geometry and Doppler, and updates the channel state. The
 navigation message for subframes 1–5 is generated with correct
 time-of-week. Each channel spreads the bits with its PRN code and the
 samples are summed into a 16‑bit I/Q stream at a configurable sample
-rate (default 8.192 MHz).
+rate (default 5.120 MHz).
 
 ## Build
 
@@ -40,7 +40,7 @@ the first chips of PRN codes using the bundled RINEX file.
 
 The build produces `bds-sim` which outputs a signed `beidou_b1i.bin`
 file containing interleaved **16‑bit little‑endian** I/Q samples. By
-default the file is written at 8.192 MHz.  Each sample is a pair of
+default the file is written at 5.120 MHz.  Each sample is a pair of
 16‑bit integers `(I,Q)` so be
 careful not to interpret the file as 8‑bit data—otherwise the Q channel
 may appear to contain only zeros or `-1` values.
@@ -55,7 +55,7 @@ The legacy option `-byte` is still recognised as an alias for `--byte`.
 ./bds-sim --rinex BRDM00DLR_S_20251760000_01D_MN.rnx \
           --start 2025/06/25,00:00:00 \
           --duration 60 \
-          --srate 8 \
+          --srate 5 \
           --gain 1.0 \
           --llh lat,lon,height \
           --byte
@@ -79,9 +79,9 @@ sample units).  The default is `0` (no noise).
 `--seed` specifies the random seed for both noise generation and the
 initial carrier phase of each channel. The default is `1`.
 
-`--srate` sets the I/Q sample rate in Hertz. Values `2`, `4` and `8`
-select the common 2.048, 4.096 and 8.192 MHz rates respectively. The
-default is `8192000`.
+`--srate` sets the I/Q sample rate in Hertz. Values `2`, `4` and `5`
+select the common 2.048, 4.096 and 5.120 MHz rates respectively. The
+default is `5120000`.
 `--byte`  forces a 25 MHz sample rate and saves an 8‑bit file containing
 only the I samples.
 
@@ -129,7 +129,7 @@ the simulation start.
 ## SDR playback
 
 The file `beidou_b1i.bin` contains interleaved **16‑bit little‑endian**
-I/Q samples written at the configured sample rate (default 8.192 MHz).
+I/Q samples written at the configured sample rate (default 5.120 MHz).
 Ensure any analysis or playback software reads the file as 16‑bit
 integers; using 8‑bit interpretation will yield
 Q samples that look like zeros.
@@ -143,7 +143,7 @@ this is typically **1561.098 MHz** – and play the samples at the same
 rate.  The following command illustrates playback with a HackRF:
 
 ```bash
-hackrf_transfer -t beidou_b1i.bin -f 1561098000 -s 8192000 -x 0
+hackrf_transfer -t beidou_b1i.bin -f 1561098000 -s 5120000 -x 0
 ```
 
 Use the `-R` option for continuous looping if needed.  Other SDRs can
@@ -164,7 +164,7 @@ searches for the correct PRNs automatically.
 * Fix UTC→BDT +14 s
 * GEO satellites enabled
 * Added subframe 4/5 template
-* Default Fs → 8.192 MHz
+* Default Fs → 5.120 MHz
 * Power scaling by target CN₀
 * Basic D2 (500 bps) support with D1 interleaving
 

--- a/bdssim.c
+++ b/bdssim.c
@@ -14,7 +14,7 @@
 #include "path.h"
 #include "globals.h"     /* nav_week */
 #define OMEGA_E   7.2921150e-5
-#define FSAMP_DEF 8.192e6    /* 8.192 MHz 更貼近商用 GNSS RF 前端 */
+#define FSAMP_DEF 5.120e6    /* 5.120 MHz 更貼近商用 GNSS RF 前端 */
 
 
 /* ---- Gaussian RNG (Box-Muller) ---- */

--- a/main.c
+++ b/main.c
@@ -31,8 +31,8 @@ int main(int argc,char *argv[])
 {
     /* 1. 預設參數 ----------------------------------- */
     sim_config_t cfg = {0};
-    /* default sample rate tuned for GNSS front-ends (8.192 MSps) */
-    cfg.sample_rate = 8192000;
+    /* default sample rate tuned for GNSS front-ends (5.120 MSps) */
+    cfg.sample_rate = 5120000;
     cfg.gain        = 1.0;
     cfg.target_cn0  = 45.0;            /* dB-Hz */
     cfg.step_ms     = 1;
@@ -126,7 +126,7 @@ int main(int argc,char *argv[])
             if(val>0 && val<1000){
                 if(fabs(val-2.0)<0.2)      cfg.sample_rate = 2048000;
                 else if(fabs(val-4.0)<0.2) cfg.sample_rate = 4096000;
-                else if(fabs(val-8.0)<0.2) cfg.sample_rate = 8192000;
+                else if(fabs(val-5.0)<0.2) cfg.sample_rate = 5120000;
                 else                       cfg.sample_rate = (uint32_t)(val*1e6+0.5);
             }else{
                 cfg.sample_rate = (uint32_t)val;


### PR DESCRIPTION
## Summary
- change default sampling rate constant to 5.120 MHz
- update command line defaults and sample rate parsing
- document new rate in README and examples

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_686cb3dc116c83279835bd3e621afbcd