### PR TITLE
Extend start time range and improve UTC conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,6 @@
 * Subframe 4/5 words set to official 0xAAAAAAAA pattern
 * Remove unused GEO helper
 * Amplitude API no longer depends on channel count
+* Allow --start up to 24 h past last ephemeris
+* Improved utc_to_bdt() handling of negative offsets
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ default is `5120000`.
 only the I samples.
 
 `--start` specifies the UTC start time; `--duration` is in seconds and
-`--llh` defines the user location in degrees and meters. These static
+`--llh` defines the user location in degrees and meters. The start time may
+extend up to 24 hours past the last ephemeris in the RINEX file; the simulator
+continues using the nearest ephemeris block for interpolation. These static
 coordinates are mutually exclusive with the dynamic path options
 `--xyz`, `--llh-file` and `--nmea`.
 Run `./bds-sim --help` to see all command options. A brief configuration

--- a/main.c
+++ b/main.c
@@ -194,7 +194,7 @@ int main(int argc,char *argv[])
     }
     double start_bdt = start_week*604800.0 + start_sow;
     if(start_bdt < nav_time_min - 3600.0 ||
-       start_bdt + cfg.duration > nav_time_max + 3600.0){
+       start_bdt + cfg.duration > nav_time_max + 86400.0){
         fputs("--start 超出星曆可用區間\n", stderr);
         return 1;
     }

--- a/timeconv.h
+++ b/timeconv.h
@@ -25,12 +25,15 @@ static inline int utc_to_bdt(const char *utc_str, int *week, double *sow)
     time_t t = timegm(&tm);          /* UTC → Unix epoch */
     const time_t bdt0 = 1136073600;  /* 2006-01-01 00:00:00 UTC */
     /* BDT 永遠比 UTC 快 14 秒 (ICD-B3, §3.4) */
+    const time_t week_sec = 604800;
     time_t diff = t - bdt0 + 14;
 
-    if (diff < 0) diff += 604800;    /* 粗略容錯（負值時補 1 週） */
+    long w = diff / week_sec;
+    long r = diff % week_sec;
+    if (r < 0) { r += week_sec; --w; }
 
-    *week = diff / 604800;
-    *sow  = (double)(diff % 604800);
+    *week = (int)w;
+    *sow  = (double)r;
     return 0;
 }
 #endif /* TIMECONV_H */


### PR DESCRIPTION
## Summary
- allow `--start` up to 24 h beyond last RINEX ephemeris
- correct cross-week handling in `utc_to_bdt`
- document extended range in README
- update changelog

## Testing
- `make`
- `make clean`


------
https://chatgpt.com/codex/tasks/task_e_686cba357e5c8327946d913529f9634d