### PR TITLE
Align D1/D2 subframes with sim start time

### DIFF
--- a/bdssim.c
+++ b/bdssim.c
@@ -95,7 +95,7 @@ int select_channels(channel_t *ch,int *n,const coord_t*u)
     for(int i=0;i<m-1;++i) for(int j=i+1;j<m;++j)
         if(c[j].elev>c[i].elev){struct cand t=c[i];c[i]=c[j];c[j]=t;}
     *n = m<MAX_CH?m:MAX_CH;
-    for(int i=0;i<*n;++i) channel_reset(&ch[i],c[i].prn);
+    for(int i=0;i<*n;++i) channel_reset(&ch[i],c[i].prn,u->week,u->sow);
     return *n;
 }
 
@@ -127,7 +127,7 @@ static void update_channels_dynamic(channel_t *ch,int *n,const coord_t *u,
         int idx=-1;
         for(int j=0;j<*n;++j) if(ch[j].prn==cand[i].prn){ idx=j; break; }
         if(idx>=0) new_ch[i]=ch[idx];
-        else       channel_reset(&new_ch[i],cand[i].prn);
+        else       channel_reset(&new_ch[i],cand[i].prn,u->week,u->sow);
         update_channel_dynamics(&new_ch[i],cand[i].rho,cand[i].rdot,
                                 gain,target_cn0);
     }

--- a/channel.c
+++ b/channel.c
@@ -83,22 +83,47 @@ static const uint8_t nh20_bits[20]={
 
 
 /* ---------- Channel helpers ---------- */
-void channel_reset(channel_t *c,int prn){
+static void load_ca_once(void)
+{
+    if(ca_ready) return;
+    for(int p=1;p<=63;++p)
+        for(int i=0;i<CODE_LEN;++i)
+            ca_wave[p][i] = prn_code[p][i]?+1:-1;
+    ca_ready = 1;
+}
+
+void channel_set_time(channel_t *c,int week,double sow)
+{
+    double sf_start = floor(sow/6.0)*6.0;
+    c->sf_id = ((int)(sf_start/6.0))%5 + 1;
+    int ms = (int)llround((sow - sf_start)*1000.0);
+    if(ms < 0)      ms = 0;
+    else if(ms >= 6000) ms = 5999;
+    c->bit_ptr = ms/20;
+    c->ms_count = ms%20;
+    get_subframe_bits(c->prn,c->sf_id,week,sf_start,c->nav_bits);
+
+    double sf_start_d2 = floor(sow/0.6)*0.6;
+    c->sf_id_d2 = ((int)(sf_start_d2/0.6))%5 + 1;
+    int ms2 = (int)llround((sow - sf_start_d2)*1000.0);
+    if(ms2 < 0)      ms2 = 0;
+    else if(ms2 >= 600) ms2 = 599;
+    c->bit_ptr_d2 = ms2/2;
+    c->ms_count_d2 = ms2%2;
+    get_subframe_bits(c->prn,c->sf_id_d2,week,sf_start_d2,c->nav_bits_d2);
+}
+
+void channel_reset(channel_t *c,int prn,int week,double sow){
     memset(c,0,sizeof(*c));
     c->prn   = prn;
-    c->sf_id = 1;                     /* start from subframe 1 */
-    c->sf_id_d2 = 1;
-    if(!ca_ready){
-        for(int p=1;p<=63;++p)
-            for(int i=0;i<CODE_LEN;++i)
-                ca_wave[p][i] = prn_code[p][i]?+1:-1;
-        ca_ready=1;
-    }
+    load_ca_once();
 
     /* Randomise starting carrier and code phase so I/Q averages
        are well balanced even for short captures. */
     c->carr_phase = ((double)rand()/(double)RAND_MAX)*PI2;
     c->code_phase = ((double)rand()/(double)RAND_MAX)*CODE_LEN;
+
+    channel_set_time(c,week,sow);
 }
 /* 幾何→計算振幅 / 初始多普勒 */
 void update_channel_dynamics(channel_t *c,double rho,double rdot,double gain,double target_cn0){

--- a/channel.h
+++ b/channel.h
@@ -25,7 +25,8 @@ typedef struct {
     uint8_t  nav_bits_d2[300];
 } channel_t;
 
-void channel_reset(channel_t *, int prn);
+void channel_reset(channel_t *, int prn, int week, double sow);
+void channel_set_time(channel_t *, int week, double sow);
 void update_channel_dynamics(channel_t *, double rho, double rdot,
                              double gain, double target_cn0);
 void channel_set_fs(double sample_rate);

--- a/navbits.c
+++ b/navbits.c
@@ -29,18 +29,20 @@ static void put_word(uint8_t *b, int pos, uint32_t w30)
 }
 
 /* --------------------------------- 子帧 1 ----------------------------------- */
-static void build_subframe1(uint8_t *out, const ephemeris_t *e, int week, double sow)
+static void build_subframe1(uint8_t *out, const ephemeris_t *e,
+                             int week, double sow)
 {
     memset(out,0,SF_STREAM_LEN);
 
     /* word1：帧同步 11 bits（11100010010） + FraID(001) + SOW[19:12] */
     uint16_t info = 0x712;            /* 11100010010 */
     info = ((info << 3)|0x1) & 0x7FF; /* +FraID=001 */
-    info = (info<<8) | ((uint32_t)sow>>12 & 0xFF);
+    uint32_t sow_int = (uint32_t)(floor(sow/6.0)*6.0);
+    info = (info<<8) | ((sow_int>>12) & 0xFF);
     put_word(out,0, make_word30(info));
 
     /* word2: SOW[11:0] (12 bits) + WN (13 bits) + reserved(?) */
-    uint32_t info2 = (((uint32_t)sow&0xFFF)<<13) | (week&0x1FFF);
+    uint32_t info2 = ((sow_int & 0xFFF)<<13) | (week&0x1FFF);
     put_word(out,30, make_word30(info2));
 
     /* word3: URA 4b, health 1b, toc(17b, /8), AODC 5b(=0) */
@@ -150,9 +152,10 @@ static void build_subframe4(uint8_t *out,int week,double sow)
     uint16_t info = 0x712;            /* sync */
     info = ((info<<3)|0x4) & 0x7FF;   /* FraID=100 */
 
-    info = (info<<8) | ((uint32_t)sow>>12 & 0xFF);
+    uint32_t sow_int = (uint32_t)(floor(sow/6.0)*6.0);
+    info = (info<<8) | ((sow_int>>12) & 0xFF);
     put_word(out,0, make_word30(info));
-    uint32_t info2 = (((uint32_t)sow&0xFFF)<<13) | (week&0x1FFF);
+    uint32_t info2 = ((sow_int&0xFFF)<<13) | (week&0x1FFF);
     put_word(out,30, make_word30(info2));
     build_sf45_template(out);
     for(int i=0;i<HALF_SUBFRAME_BITS;i++) out[i+HALF_SUBFRAME_BITS]=out[i];
@@ -167,9 +170,10 @@ static void build_subframe5(uint8_t *out,int week,double sow)
     uint16_t info = 0x712;            /* sync */
     info = ((info<<3)|0x5) & 0x7FF;   /* FraID=101 */
 
-    info = (info<<8) | ((uint32_t)sow>>12 & 0xFF);
+    uint32_t sow_int = (uint32_t)(floor(sow/6.0)*6.0);
+    info = (info<<8) | ((sow_int>>12) & 0xFF);
     put_word(out,0, make_word30(info));
-    uint32_t info2 = (((uint32_t)sow&0xFFF)<<13) | (week&0x1FFF);
+    uint32_t info2 = ((sow_int & 0xFFF)<<13) | (week&0x1FFF);
     put_word(out,30, make_word30(info2));
     build_sf45_template(out);
     for(int i=0;i<HALF_SUBFRAME_BITS;i++) out[i+HALF_SUBFRAME_BITS]=out[i];


### PR DESCRIPTION
## Summary
- add channel_set_time helper and extend channel_reset to set start time
- ensure nav subframe SOW is aligned to 6‑s boundaries
- reset or newly added channels using the current time

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_686cc26a66cc8327a324754cd1fdeec7