### PR TITLE
Fix D2 subframe timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ enabled satellite channel spreads these bits with the appropriate PRN
 code.  The 50 bps D1 navigation message is further modulated by the
 standard 20‑bit Neumann–Hoffman sequence so that the resulting signal
 matches the BeiDou B1I specification.  Optionally a 500 bps D2 message
-without secondary coding and can be interleaved every other millisecond.
+without secondary coding can be interleaved every other millisecond.
 Finally the channels are summed to
 produce complex baseband samples ready for SDR playback.
 The output is ready to be transmitted by an SDR.

--- a/bdssim.h
+++ b/bdssim.h
@@ -48,7 +48,7 @@ typedef struct {
     double   noise_std;        /* AWGN 標準差 (0 表示無) */
     unsigned noise_seed;       /* AWGN 亂數種子 */
     bool     byte_output;      /* 以 8-bit 檔輸出 */
-    bool     enable_d2;        /* 啟用 D2 播放 */
+    bool     enable_d2;        /* 啟用 D2 播放（與 D1 交錯） */
 } sim_config_t;
 
 /* ---------- 介面 ---------- */

--- a/channel.c
+++ b/channel.c
@@ -101,7 +101,7 @@ void channel_set_time(channel_t *c,int week,double sow)
     else if(ms >= 6000) ms = 5999;
     c->bit_ptr = ms/20;
     c->ms_count = ms%20;
-    get_subframe_bits(c->prn,c->sf_id,week,sf_start,c->nav_bits);
+    get_subframe_bits(c->prn,c->sf_id,week,sf_start,6.0,c->nav_bits);
 
     double sf_start_d2 = floor(sow/0.6)*0.6;
     c->sf_id_d2 = ((int)(sf_start_d2/0.6))%5 + 1;
@@ -110,7 +110,7 @@ void channel_set_time(channel_t *c,int week,double sow)
     else if(ms2 >= 600) ms2 = 599;
     c->bit_ptr_d2 = ms2/2;
     c->ms_count_d2 = ms2%2;
-    get_subframe_bits(c->prn,c->sf_id_d2,week,sf_start_d2,c->nav_bits_d2);
+    get_subframe_bits(c->prn,c->sf_id_d2,week,sf_start_d2,0.6,c->nav_bits_d2);
 }
 
 void channel_reset(channel_t *c,int prn,int week,double sow){
@@ -147,7 +147,7 @@ void gen_samples_1ms(channel_t *c,int week,double sow,
                      int samp_per_ms,int16_t*I,int16_t*Q)
 {
     if(c->bit_ptr==0 && c->ms_count==0)
-        get_subframe_bits(c->prn,c->sf_id,week,sow,c->nav_bits);
+        get_subframe_bits(c->prn,c->sf_id,week,sow,6.0,c->nav_bits);
 
     /* Baseband output – only apply Doppler frequency */
     const double dphi = PI2*c->fd/fs;
@@ -189,13 +189,12 @@ void gen_samples_1ms(channel_t *c,int week,double sow,
  * ======== D2 (500 bps) support ========
  *  - 資料速率 500 bps (2 ms per bit)
  *  - 不使用二次 Neumann-Hoffman 編碼
- *  - 與 D1 交錯：偶數毫秒 Tx D2，奇數毫秒 Tx D1
  */
 void gen_samples_1ms_d2(channel_t *c, int week, double sow,
                                int samp_per_ms, int16_t *I, int16_t *Q)
 {
     if(c->bit_ptr_d2==0 && c->ms_count_d2==0)
-        get_subframe_bits(c->prn,c->sf_id_d2,week,sow,c->nav_bits_d2);
+        get_subframe_bits(c->prn,c->sf_id_d2,week,sow,0.6,c->nav_bits_d2);
 
     const double dphi = PI2*c->fd/fs;
     const double dcode = c->code_rate/fs;

--- a/channel.h
+++ b/channel.h
@@ -18,10 +18,10 @@ typedef struct {
     uint8_t  sf_id;
     uint8_t  ms_count;      /* 0~19: ms index within data bit */
     uint8_t  nav_bits[300]; /* cached subframe bits */
-    /* ---- D2 state (1 kbps) ---- */
+    /* ---- D2 state (500 bps) ---- */
     uint16_t bit_ptr_d2;
     uint8_t  sf_id_d2;
-    uint8_t  ms_count_d2;   /* 0~9 */
+    uint8_t  ms_count_d2;   /* 0~1 */
     uint8_t  nav_bits_d2[300];
 } channel_t;
 
@@ -37,7 +37,7 @@ void gen_samples_1ms_d2(channel_t *, int week, double sow,
 
 /* === 修正：用指標而非 array declarator === */
 void get_subframe_bits(int prn, int sf_id, int week, double sow,
-                       uint8_t *out);   /* out[300] */
+                       double frame_len, uint8_t *out);   /* out[300] */
 
 #endif
 

--- a/main.c
+++ b/main.c
@@ -24,6 +24,7 @@ static void usage(const char *p)
     puts("  --seed n            雜訊亂數種子 (整數)");
     puts("  --srate Hz           取樣率 (Hz)");
     puts("  --byte               25MHz 取樣率並僅輸出 I 之 8-bit 檔");
+    puts("  --enable-d2          產生 D2 (500bps) 導航訊息");
     puts("  --help               顯示本說明\n");
 }
 

--- a/navbits.c
+++ b/navbits.c
@@ -193,19 +193,20 @@ void navbits_init(void)
 }
 
 /* 根據時間取得子帧 bit 流 (300 bits) */
-void get_subframe_bits(int prn,int sf_id,int week,double sow,uint8_t *out)
+void get_subframe_bits(int prn,int sf_id,int week,double sow,
+                       double frame_len,uint8_t *out)
 {
+    double start = floor(sow/frame_len)*frame_len;
     if(sf_id==1){
-        build_subframe1(out,&eph[prn],week,sow);
+        build_subframe1(out,&eph[prn],week,start);
     }else if(sf_id==2){
         memcpy(out,sf_static[prn][0],SF_STREAM_LEN);
     }else if(sf_id==3){
         memcpy(out,sf_static[prn][1],SF_STREAM_LEN);
     }else if(sf_id==4){
-
-        build_subframe4(out,week,sow);
+        build_subframe4(out,week,start);
     }else if(sf_id==5){
-        build_subframe5(out,week,sow);
+        build_subframe5(out,week,start);
 
     }else{
         memset(out,0,SF_STREAM_LEN);

--- a/navbits.h
+++ b/navbits.h
@@ -11,7 +11,8 @@
 #define SF_STREAM_LEN (SUBFRAME_BITS)
 
 void navbits_init(void);
-void get_subframe_bits(int prn, int sf_id, int week, double sow, uint8_t *out); /* sf_id=1..5 */
+void get_subframe_bits(int prn, int sf_id, int week, double sow,
+                       double frame_len, uint8_t *out); /* sf_id=1..5 */
 
 #endif
 


### PR DESCRIPTION
## Summary
- compute subframe start using frame length
- apply 0.6 s frame length for D2 subframes
- update header prototypes

## Testing
- `make`
- `make prn_test`


------
https://chatgpt.com/codex/tasks/task_e_686cc9e0705c8327bee13cb18c912473