### PR TITLE
Implement PRN-based D1/D2 selection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,17 @@ bds-sim: $(OBJS)
 prn_test: prn_test.o globals.o bch.o navbits.o channel.o rinex.o orbits.o coord.o path.o bdssim.o
 	$(CC) $(CFLAGS) $^ -o $@ -lm
 
+tests/test_prn_d1d2: tests/test_prn_d1d2.o globals.o bch.o navbits.o channel.o rinex.o orbits.o coord.o path.o bdssim.o
+	$(CC) $(CFLAGS) $^ -o $@ -lm
+
+check: tests/test_prn_d1d2
+	./tests/test_prn_d1d2
+
 %.o: %.c
 	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
-	       rm -f *.o bds-sim prn_test test_beidou *.bin *.gz
+	rm -f *.o bds-sim prn_test test_beidou tests/test_prn_d1d2 tests/test_prn_d1d2.o *.bin *.gz
 	@echo "✅ 已清除中間檔與 .gz 暫存檔"
 
 # =====================[ 下載區 ]=====================

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ I channel only for quick inspection.  The Q samples are discarded
 entirely.
 The legacy option `-byte` is still recognised as an alias for `--byte`.
 
+## 訊號型別
+
+- GEO PRN → D2 (500 bps, 無 NH 二次碼)
+- MEO/IGSO PRN → D1 (50 bps, 有 NH 二次碼)
+- `--force-d2` 可把所有 PRN 強制成 D2
+
 ## Usage
 
 ```

--- a/bdssim.c
+++ b/bdssim.c
@@ -220,8 +220,8 @@ void generate_signal(const sim_config_t *cfg)
             /* 併行各通道 */
             #pragma omp parallel for
             for(int c=0;c<n_ch;++c){
-                uint64_t curr_ms = ms + step;
-                if(cfg->enable_d2 && (curr_ms % 2 == 0))
+                bool use_d2 = cfg->force_d2 || is_d2_prn(ch[c].prn);
+                if(use_d2)
                     gen_samples_1ms_d2(&ch[c],week,sow+step*0.001,
                                        samp_per_ms,tmpI[c],tmpQ[c]);
                 else

--- a/bdssim.h
+++ b/bdssim.h
@@ -47,7 +47,7 @@ typedef struct {
     double   noise_std;        /* AWGN 標準差 (0 表示無) */
     unsigned noise_seed;       /* AWGN 亂數種子 */
     bool     byte_output;      /* 以 8-bit 檔輸出 */
-    bool     enable_d2;        /* 啟用 D2 播放（與 D1 交錯） */
+    bool     force_d2;         /* 強制所有 PRN 使用 D2 */
 } sim_config_t;
 
 /* ---------- 介面 ---------- */

--- a/channel.c
+++ b/channel.c
@@ -50,6 +50,11 @@ static int is_geo_prn(int prn)
     return 0;
 }
 
+int is_d2_prn(int prn)
+{
+    return is_geo_prn(prn);
+}
+
 static double sat_eirp_dbm(int prn)
 {
     if(is_geo_prn(prn))      return 52.0; /* GEO */

--- a/channel.h
+++ b/channel.h
@@ -34,6 +34,7 @@ void gen_samples_1ms(channel_t *, int week, double sow,
                      int samp_per_ms, int16_t *I, int16_t *Q);
 void gen_samples_1ms_d2(channel_t *, int week, double sow,
                         int samp_per_ms, int16_t *I, int16_t *Q);
+int  is_d2_prn(int prn);
 
 /* === 修正：用指標而非 array declarator === */
 void get_subframe_bits(int prn, int sf_id, int week, double sow,

--- a/main.c
+++ b/main.c
@@ -23,7 +23,7 @@ static void usage(const char *p)
     puts("  --noise stddev       加入 AWGN 雜訊標準差");
     puts("  --seed n            雜訊亂數種子 (整數)");
     puts("  --byte               輸出 I-only 之 8-bit 檔");
-    puts("  --enable-d2          產生 D2 (500bps) 導航訊息");
+    puts("  --force-d2           所有 PRN 強制採用 D2 信號");
     puts("  --help               顯示本說明\n");
 }
 
@@ -38,7 +38,7 @@ int main(int argc,char *argv[])
     cfg.noise_std   = 0.0;
     cfg.noise_seed  = 1;
     cfg.byte_output = false;
-    cfg.enable_d2  = false;
+    cfg.force_d2  = false;
     bool llh_given   = false;
 
     /* 處理 "-byte" 舊習慣 */
@@ -60,7 +60,7 @@ int main(int argc,char *argv[])
         {"noise",    required_argument, 0, 'z'},
         {"seed",     required_argument, 0, 'R'},
         {"byte",     no_argument,       0, 'b'},
-        {"enable-d2",no_argument,       0, 'D'},
+        {"force-d2", no_argument,       0, 'D'},
         {"help",     no_argument,       0, 'h'},
         {0,0,0,0}
     };
@@ -122,7 +122,7 @@ int main(int argc,char *argv[])
             cfg.byte_output = true;
             break;
         case 'D':
-            cfg.enable_d2 = true;
+            cfg.force_d2 = true;
             break;
         case 'h':
             usage(argv[0]);

--- a/tests/test_prn_d1d2.c
+++ b/tests/test_prn_d1d2.c
@@ -1,0 +1,43 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <assert.h>
+#include "../bdssim.h"
+#include "../channel.h"
+#include "../globals.h"
+
+int main(void){
+    sim_config_t cfg = {0};
+    snprintf(cfg.rinex_file, sizeof(cfg.rinex_file),
+             "BRDM00DLR_S_20251760000_01D_MN.rnx");
+    if(!init_simulator(&cfg)){
+        fprintf(stderr, "init failed\n");
+        return 1;
+    }
+
+    assert(is_d2_prn(3));
+    assert(!is_d2_prn(8));
+
+    channel_t c3, c8;
+    channel_reset(&c3, 3, nav_week, 0.0);
+    channel_reset(&c8, 8, nav_week, 0.0);
+    channel_set_fs(5.12e6);
+    int samp_per_ms = (int)(5.12e6/1000.0 + 0.5);
+    int16_t I[samp_per_ms], Q[samp_per_ms];
+
+    for(int i=0;i<10;i++){
+        gen_samples_1ms_d2(&c3, nav_week, i*0.001, samp_per_ms, I, Q);
+        gen_samples_1ms(&c8, nav_week, i*0.001, samp_per_ms, I, Q);
+    }
+
+    if(c3.bit_ptr_d2 < 1 || c3.bit_ptr_d2 != 5){
+        fprintf(stderr, "PRN3 not D2 as expected (bit_ptr_d2=%u)\n", c3.bit_ptr_d2);
+        return 1;
+    }
+    if(c8.bit_ptr != 0){
+        fprintf(stderr, "PRN8 unexpected bit progress (bit_ptr=%u)\n", c8.bit_ptr);
+        return 1;
+    }
+
+    cleanup_simulator();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add helper `is_d2_prn()` alongside `is_geo_prn`
- determine D1/D2 per channel based on `--force-d2` or PRN
- rename CLI option `--enable-d2` to `--force-d2`
- document signal types and new option in README
- provide unit test verifying PRN3 uses D2 and PRN8 uses D1

## Testing
- `make clean && make -j`
- `./bds-sim --rinex BRDM00DLR_S_20251760000_01D_MN.rnx --start 2025/06/25,00:00:00 --duration 1 --llh 25,121,0`
- `make tests/test_prn_d1d2`
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_686e0a005c9883278d1a6590a0a585b1