### PR TITLE
Support 25MHz sample rate for byte output

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ Run `make check` to build and execute the self test
 
 The build produces `bds-sim` which outputs a signed `beidou_b1i.bin`
 file containing interleaved **16‑bit little‑endian** I/Q samples. By
-default the file is written at 5.120 MHz.  Each sample is a pair of
+default the file is written at **5.120 MHz**.  Each sample is a pair of
 16‑bit integers `(I,Q)` so be
 careful not to interpret the file as 8‑bit data—otherwise the Q channel
 may appear to contain only zeros or `-1` values.
 Using the `--byte` flag writes `beidou_b1i_u8.bin` containing the **8‑bit**
-I channel only for quick inspection.  The Q samples are discarded
-entirely.
+I channel only, sampled at **25 MHz** for use with GNSS‑SDR.  The Q samples are
+discarded entirely.
 The legacy option `-byte` is still recognised as an alias for `--byte`.
 
 ## 訊號型別
@@ -152,12 +152,12 @@ This builds and runs `tests/test_prn_d1d2` to verify D1/D2 generation.
 ## SDR playback
 
 The file `beidou_b1i.bin` contains interleaved **16‑bit little‑endian**
-I/Q samples written at a fixed 5.120 MHz sample rate.
+I/Q samples written at a fixed **5.120 MHz** sample rate.
 Ensure any analysis or playback software reads the file as 16‑bit
 integers; using 8‑bit interpretation will yield
 Q samples that look like zeros.
 When `--byte` is used, the output file `beidou_b1i_u8.bin` stores only the
-I samples in signed 8‑bit format.  Only the real component is retained;
+I samples in signed 8‑bit format at **25 MHz**.  Only the real component is retained;
 Q is not saved.
 
 The signal is at baseband (zero‑IF), so tune the

--- a/bdssim.c
+++ b/bdssim.c
@@ -14,7 +14,8 @@
 #include "path.h"
 #include "globals.h"     /* nav_week */
 #define OMEGA_E   7.2921150e-5
-#define FSAMP_DEF 5.120e6    /* 5.120 MHz 更貼近商用 GNSS RF 前端 */
+#define FSAMP_DEF 5.120e6    /* default 5.120 MHz for 16-bit I/Q output */
+#define FSAMP_BYTE 25.0e6    /* 25 MHz when --byte is used */
 
 
 /* ---- Gaussian RNG (Box-Muller) ---- */
@@ -159,6 +160,10 @@ void generate_signal(const sim_config_t *cfg)
 
     channel_t ch[MAX_CH]; int n_ch; select_channels(ch,&n_ch,&usr);
 
+    double fs = cfg->byte_output ? FSAMP_BYTE : FSAMP_DEF;
+    int samp_per_ms = (int)(fs/1000.0 + 0.5);
+    channel_set_fs(fs);                   /* ensure dynamics use correct Fs */
+
     double uvel[3]={-OMEGA_E*usr.xyz[1], OMEGA_E*usr.xyz[0], 0.0};
     /* 首次幾何 – 初始化振幅/NCO */
     for(int i=0;i<n_ch;++i){
@@ -170,10 +175,6 @@ void generate_signal(const sim_config_t *cfg)
         update_channel_dynamics(&ch[i],rho,rdot,cfg->gain,cfg->target_cn0);
         printf("[ch%02d] rdot %.2f fd %.2fHz\n", ch[i].prn, rdot, ch[i].fd);
     }
-
-    double fs = FSAMP_DEF;
-    int samp_per_ms = (int)(fs/1000.0 + 0.5);
-    channel_set_fs(fs);
 
     FILE *fp=NULL, *fp8=NULL;
     if(cfg->byte_output){

--- a/main.c
+++ b/main.c
@@ -209,8 +209,9 @@ int main(int argc,char *argv[])
            usr.xyz[0], usr.xyz[1], usr.xyz[2]);
     printf("[cfg] PRN:");
     for(int i=0;i<n_ch;i++) printf(" %02d", ch[i].prn);
-    printf("  Fs %.1fMHz  Gain %.2f\n\n",
-           5.12, cfg.gain);
+    double fs_out = cfg.byte_output ? 25.0 : 5.12;
+    printf("  Fs %.2fMHz  Gain %.2f\n\n",
+           fs_out, cfg.gain);
 
     /* 4. 產生基帶 ----------------------------------- */
     generate_signal(&cfg);


### PR DESCRIPTION
## Summary
- add FSAMP_BYTE constant for 25 MHz
- switch to 25 MHz when `--byte` is used
- show actual sample rate in configuration summary
- document new byte-output sample rate in README
- ensure channels use the correct sample rate before computing dynamics

## Testing
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_686e33c0b2f48327b259a8fd91e1fd21