### PR TITLE
Implement ICD word structs and builder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,16 @@
 CC      = gcc
 CFLAGS = -O2 -Wall -Wextra -fopenmp -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE
 
-OBJS = main.o globals.o bch.o navbits.o channel.o \
+OBJS = main.o globals.o bch.o nav_words.o nav_pages.o navbits.o channel.o \
        bdssim.o rinex.o orbits.o coord.o path.o
        
 bds-sim: $(OBJS)
 	$(CC) $(CFLAGS) -o $@ $(OBJS) -lm
 
-prn_test: prn_test.o globals.o bch.o navbits.o channel.o rinex.o orbits.o coord.o path.o bdssim.o
+prn_test: prn_test.o globals.o bch.o nav_words.o nav_pages.o navbits.o channel.o rinex.o orbits.o coord.o path.o bdssim.o
 	$(CC) $(CFLAGS) $^ -o $@ -lm
 
-tests/test_prn_d1d2: tests/test_prn_d1d2.o globals.o bch.o navbits.o channel.o rinex.o orbits.o coord.o path.o bdssim.o
+tests/test_prn_d1d2: tests/test_prn_d1d2.o globals.o bch.o nav_words.o nav_pages.o navbits.o channel.o rinex.o orbits.o coord.o path.o bdssim.o
 	$(CC) $(CFLAGS) $^ -o $@ -lm
 
 check: tests/test_prn_d1d2

--- a/bch.c
+++ b/bch.c
@@ -15,3 +15,17 @@ uint16_t bch_encode(uint16_t d11)
 }
 
 
+
+/* Generic BCH(15,11,1) encoder returning parity bits for 22 or 26 bit payloads */
+uint32_t bch1511(uint32_t in, int payloadBits)
+{
+    if (payloadBits != 22 && payloadBits != 26)
+        return 0;
+    int parityBits = (payloadBits == 26) ? 4 : 8;
+    uint32_t reg = in << parityBits;  /* space for parity */
+    int top = payloadBits + parityBits - 1;
+    for (int i = top; i >= parityBits; --i)
+        if (reg & (1u << i))
+            reg ^= (uint32_t)G << (i - 4);
+    return reg & ((1u << parityBits) - 1);
+}

--- a/bch.h
+++ b/bch.h
@@ -3,5 +3,7 @@
 #include <stdint.h>
 /* 將 11 bit 資訊位編成 15 bit BCH(15,11,1) */
 uint16_t bch_encode(uint16_t info);
+/* 通用 BCH(15,11,1) for longer payloads (22 or 26 bits). */
+uint32_t bch1511(uint32_t in, int payloadBits);
 #endif
 

--- a/icd_fields.h
+++ b/icd_fields.h
@@ -1,0 +1,49 @@
+#ifndef ICD_FIELDS_H
+#define ICD_FIELDS_H
+#include <stdint.h>
+
+/* BeiDou B1I D1 frame fields extracted from ICD.
+ * Each member width is noted in bits for reference. */
+typedef struct {
+    uint32_t sow;        /* 20 bits */
+    uint32_t satH1;      /* 1 bit  */
+    uint32_t aodc;       /* 5 bits */
+    uint32_t urai;       /* 4 bits */
+    uint32_t toc;        /* 17 bits */
+    int32_t  a0;         /* 24 bits signed */
+    int32_t  a1;         /* 22 bits signed */
+    int32_t  a2;         /* 11 bits signed */
+    int32_t  tgd1;       /* 10 bits signed */
+    int32_t  tgd2;       /* 10 bits signed */
+    int32_t  alpha[4];   /* 8 bits each signed */
+    int32_t  beta[4];    /* 8 bits each signed */
+
+    /* orbital parameters --------------------------------------- */
+    int32_t  delta_n;    /* 16 bits signed */
+    int32_t  M0;         /* 32 bits signed */
+    int32_t  e;          /* 32 bits unsigned scaled */
+    int32_t  sqrtA;      /* 32 bits unsigned scaled */
+    int32_t  cuc;        /* 18 bits signed */
+    int32_t  cus;        /* 18 bits signed */
+    int32_t  crc;        /* 18 bits signed */
+    int32_t  crs;        /* 18 bits signed */
+    uint32_t toe;        /* 17 bits */
+    uint32_t aode;       /* 5 bits */
+    int32_t  i0;         /* 32 bits signed */
+    int32_t  omega0;     /* 32 bits signed */
+    int32_t  omega;      /* 32 bits signed */
+    int32_t  omegadot;   /* 24 bits signed */
+    int32_t  idot;       /* 14 bits signed */
+    int32_t  cic;        /* 18 bits signed */
+    int32_t  cis;        /* 18 bits signed */
+} B1I_D1_Frame;
+
+/* D2 frame uses a similar layout but additional paging flags. Only a
+ * small subset is defined here for demonstration. */
+typedef struct {
+    uint32_t sow;        /* 12 bits */
+    uint32_t page;       /* 7 bits */
+    uint32_t toc;        /* 17 bits */
+} B1I_D2_Frame;
+
+#endif /* ICD_FIELDS_H */

--- a/nav_pages.c
+++ b/nav_pages.c
@@ -1,0 +1,24 @@
+#include <stdint.h>
+#include <string.h>
+#include "icd_fields.h"
+#include "nav_words.h"
+
+/*
+ * Placeholder implementation that assembles a D1 subframe using
+ * the provided fields. Only the first two words are constructed
+ * to demonstrate the new build_word() helper. Remaining words are
+ * left zero so that existing functionality is preserved.
+ */
+void assemble_d1_subframe(int sfid, const B1I_D1_Frame *frm,
+                          int week, uint32_t sow, uint32_t words[10])
+{
+    memset(words, 0, sizeof(uint32_t) * 10);
+    if (!frm) return;
+
+    if (sfid == 1) {
+        uint32_t w1_payload = (0x712 << 3 | sfid) << 8 | ((sow >> 12) & 0xFF);
+        words[0] = build_word(w1_payload, 26);
+        uint32_t w2_payload = ((sow & 0xFFF) << 13) | (week & 0x1FFF);
+        words[1] = build_word(w2_payload, 26);
+    }
+}

--- a/nav_pages.h
+++ b/nav_pages.h
@@ -1,0 +1,7 @@
+#ifndef NAV_PAGES_H
+#define NAV_PAGES_H
+#include <stdint.h>
+#include "icd_fields.h"
+void assemble_d1_subframe(int sfid, const B1I_D1_Frame *frm,
+                          int week, uint32_t sow, uint32_t words[10]);
+#endif

--- a/nav_words.c
+++ b/nav_words.c
@@ -1,0 +1,15 @@
+#include <stdint.h>
+#include "bch.h"
+#include "nav_words.h"
+
+/* Build a 30-bit navigation word from payload bits.
+ * payload: left aligned (MSB first) within 'bits' width.
+ * bits    : number of information bits (22 or 26).
+ */
+uint32_t build_word(uint32_t payload, int bits)
+{
+    uint32_t word = payload << (30 - bits);
+    uint32_t parity = bch1511(payload, bits);
+    word |= parity & ((bits==26)?0xF:0xFF);
+    return word;
+}

--- a/nav_words.h
+++ b/nav_words.h
@@ -1,0 +1,5 @@
+#ifndef NAV_WORDS_H
+#define NAV_WORDS_H
+#include <stdint.h>
+uint32_t build_word(uint32_t payload, int bits);
+#endif

--- a/navbits.c
+++ b/navbits.c
@@ -4,22 +4,11 @@
 #include <string.h>
 #include "navbits.h"
 #include "bch.h"
+#include "nav_words.h"
 
 extern ephemeris_t eph[MAX_SAT];
 
 /* --------------------------------- 宏 & 工具 -------------------------------- */
-static uint32_t make_word30(uint32_t info11)
-{
-    /* info11(高→低) 先 BCH(15,11,1) 產出 15 bits，再左右交织成 30 bits */
-    uint16_t bch = bch_encode(info11);
-    uint32_t w = 0;
-    for(int i=0;i<15;i++){
-        w <<= 2;
-        w |= ((info11>>(14-i))&1);      /* 左：信息位 */
-        w |= ((bch    >>i)&1)<<1;       /* 右：校验位 */
-    }
-    return w;
-}
 
 /* 填 30-bit word 至 bit 流。pos 為 bit index 0..299 (MSB first) */
 static void put_word(uint8_t *b, int pos, uint32_t w30)
@@ -48,25 +37,25 @@ static void build_subframe1(uint8_t *out, const ephemeris_t *e,
        start of the current subframe length. */
     uint32_t sow_int = (uint32_t)(floor(sow/frame_len)*frame_len);
     info = (info<<8) | ((sow_int>>12) & 0xFF);
-    put_word(out,0, make_word30(info));
+    put_word(out,0, build_word(info, 26));
 
     /* word2: SOW[11:0] (12 bits) + WN (13 bits) + reserved(?) */
     uint32_t info2 = ((sow_int & 0xFFF)<<13) | (week&0x1FFF);
-    put_word(out,30, make_word30(info2));
+    put_word(out,30, build_word(info2, 26));
 
     /* word3: URA 4b, health 1b, toc(17b, /8), AODC 5b(=0) */
     uint32_t info3 = (e->ura & 0xF)<<26 | (e->health&1)<<25 | ((uint32_t)(e->toc/8)&0x1FFFF)<<8;
-    put_word(out,60, make_word30(info3));
+    put_word(out,60, build_word(info3, 26));
 
     /* word4: af0 (dt=2^-33) 22 bits → twos-comp */
     int32_t a0_i = (int32_t)llround(e->af0 / pow(2,-33));
-    put_word(out,90, make_word30((uint32_t)(a0_i & 0x3FFFFF)));
+    put_word(out,90, build_word((uint32_t)(a0_i & 0x3FFFFF), 26));
 
     /* word5: af1 16 bits(+2^-50)、af2 11 bits(+2^-66) */
     int32_t a1_i = (int32_t)llround(e->af1 / pow(2,-50));
     int32_t a2_i = (int32_t)llround(e->af2 / pow(2,-66));
     uint32_t info5 = ((a1_i & 0xFFFF)<<11) | (a2_i & 0x7FF);
-    put_word(out,120, make_word30(info5));
+    put_word(out,120, build_word(info5, 22));
 
     /* 前 5 words 重複一次構成 10 words */
     for(int i=0;i<HALF_SUBFRAME_BITS;i++) out[i+HALF_SUBFRAME_BITS]=out[i];
@@ -81,27 +70,27 @@ static void build_subframe2(uint8_t *out, const ephemeris_t *e)
     uint16_t info = 0x712;            /* sync */
     info = ((info<<3)|0x2) & 0x7FF;   /* FraID=010 */
     info = (info<<8) | ((uint32_t)e->toe>>8 &0xFF);
-    put_word(out,0, make_word30(info));
+    put_word(out,0, build_word(info, 26));
 
     /* word2: toe[7:0] + √A[21:13] */
     uint32_t info2 = ((uint32_t)e->toe &0xFF)<<13 |
                      (uint32_t)(llround(e->sqrtA/pow(2,-19))>>13 &0x1FFF);
-    put_word(out,30, make_word30(info2));
+    put_word(out,30, build_word(info2, 26));
 
     /* word3: √A[12:0] + e[21:11] */
     uint32_t sqrtA_i = (uint32_t)llround(e->sqrtA/pow(2,-19));
     uint32_t e_i     = (uint32_t)llround(e->e     /pow(2,-33));
     uint32_t info3 = (sqrtA_i &0x1FFF)<<11 | (e_i>>11 &0x7FF);
-    put_word(out,60, make_word30(info3));
+    put_word(out,60, build_word(info3, 26));
 
     /* word4: e[10:0] + Δn(16b,+2^-43) + M0[21] */
     uint32_t dn_i = (int32_t)llround(e->deltan/pow(2,-43)) & 0xFFFF;
     uint32_t M0_i = (int32_t)llround(e->M0/pow(2,-31));
     uint32_t info4 = (e_i &0x7FF)<<19 | dn_i<<3 | (M0_i>>21 &0x7);
-    put_word(out,90, make_word30(info4));
+    put_word(out,90, build_word(info4, 26));
 
     /* word5: M0[20:0] 首段 */
-    put_word(out,120, make_word30(M0_i & 0x1FFFFF));
+    put_word(out,120, build_word(M0_i & 0x1FFFFF, 22));
 
     for(int i=0;i<HALF_SUBFRAME_BITS;i++) out[i+HALF_SUBFRAME_BITS]=out[i];
 }
@@ -116,28 +105,28 @@ static void build_subframe3(uint8_t *out, const ephemeris_t *e)
     info = ((info<<3)|0x3) & 0x7FF;
     int32_t O0_i = (int32_t)llround(e->omega0 / pow(2,-31));
     info = (info<<8) | ((O0_i>>14)&0xFF);
-    put_word(out,0, make_word30(info));
+    put_word(out,0, build_word(info, 26));
 
     /* word2: Ω0[13:0] + i0[21:13] */
     int32_t i0_i = (int32_t)llround(e->i0 / pow(2,-31));
     uint32_t info2 = ((O0_i &0x3FFF)<<13) | ((i0_i>>13)&0x1FFF);
-    put_word(out,30, make_word30(info2));
+    put_word(out,30, build_word(info2, 26));
 
     /* word3: i0[12:0] + ω[21:11] */
     int32_t w_i = (int32_t)llround(e->w / pow(2,-31));
     uint32_t info3 = ((i0_i &0x1FFF)<<11) | ((w_i>>11)&0x7FF);
-    put_word(out,60, make_word30(info3));
+    put_word(out,60, build_word(info3, 26));
 
     /* word4: ω[10:0] + CRC + IDOT[10] */
     int32_t crc_i = (int32_t)llround(e->crc / pow(2,-5));       /* 18 bits */
     int32_t idot_i= (int32_t)llround(e->idot/ pow(2,-43));      /* 14 bits → 11+3 */
     uint32_t info4 = ((w_i &0x7FF)<<19) | ((crc_i&0x3FFFF)<<1) | ((idot_i>>10)&1);
-    put_word(out,90, make_word30(info4));
+    put_word(out,90, build_word(info4, 26));
 
     /* word5: IDOT[9:0] + Ω̇ dot[23:?] */
     int32_t odot_i = (int32_t)llround(e->omegadot / pow(2,-43));/* 24 bits */
     uint32_t info5 = ((idot_i &0x3FF)<<20) | (odot_i &0xFFFFF);
-    put_word(out,120, make_word30(info5));
+    put_word(out,120, build_word(info5, 22));
 
     for(int i=0;i<HALF_SUBFRAME_BITS;i++) out[i+HALF_SUBFRAME_BITS]=out[i];
 }
@@ -163,9 +152,9 @@ static void build_subframe4(uint8_t *out,int week,double sow,double frame_len)
 
     uint32_t sow_int = (uint32_t)(floor(sow/frame_len)*frame_len);
     info = (info<<8) | ((sow_int>>12) & 0xFF);
-    put_word(out,0, make_word30(info));
+    put_word(out,0, build_word(info, 26));
     uint32_t info2 = ((sow_int&0xFFF)<<13) | (week&0x1FFF);
-    put_word(out,30, make_word30(info2));
+    put_word(out,30, build_word(info2, 26));
     build_sf45_template(out);
     for(int i=0;i<HALF_SUBFRAME_BITS;i++) out[i+HALF_SUBFRAME_BITS]=out[i];
 }
@@ -181,9 +170,9 @@ static void build_subframe5(uint8_t *out,int week,double sow,double frame_len)
 
     uint32_t sow_int = (uint32_t)(floor(sow/frame_len)*frame_len);
     info = (info<<8) | ((sow_int>>12) & 0xFF);
-    put_word(out,0, make_word30(info));
+    put_word(out,0, build_word(info, 26));
     uint32_t info2 = ((sow_int & 0xFFF)<<13) | (week&0x1FFF);
-    put_word(out,30, make_word30(info2));
+    put_word(out,30, build_word(info2, 26));
     build_sf45_template(out);
     for(int i=0;i<HALF_SUBFRAME_BITS;i++) out[i+HALF_SUBFRAME_BITS]=out[i];
 }


### PR DESCRIPTION
## Summary
- add new `B1I_D1_Frame` and `B1I_D2_Frame` in `icd_fields.h`
- implement generic `bch1511` and 30‑bit word builder
- restructure Makefile to build new modules
- wire navigation bit generator to use `build_word`
- provide placeholder `assemble_d1_subframe`

## Testing
- `make clean`
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_686f77c278048327947965fc7a1e8c2b