### PR TITLE
Fix subframe header construction

### DIFF
--- a/nav_words.c
+++ b/nav_words.c
@@ -2,12 +2,33 @@
 #include "bch.h"
 #include "nav_words.h"
 
-/* Build a 30-bit navigation word from payload bits.
- * payload: left aligned (MSB first) within 'bits' width.
- * bits    : number of information bits (22 or 26).
+/* Build a 30-bit navigation word following the BeiDou ICD.
+ * bits must be either 26 (first word with a 15-bit unencoded prefix
+ * and 11-bit BCH block) or 22 (two interleaved BCH blocks).
  */
 uint32_t build_word(uint32_t payload, int bits)
 {
+    if (bits == 22) {
+        /* split into two 11-bit groups and interleave the BCH codes */
+        uint16_t infoA = (payload >> 11) & 0x7FF;
+        uint16_t infoB = payload & 0x7FF;
+        uint16_t codeA = bch_encode(infoA);
+        uint16_t codeB = bch_encode(infoB);
+        uint32_t w = 0;
+        for (int i = 14; i >= 0; --i) {
+            w = (w << 1) | ((codeA >> i) & 1);
+            w = (w << 1) | ((codeB >> i) & 1);
+        }
+        return w;
+    } else if (bits == 26) {
+        /* 15-bit prefix followed by one BCH(15,11,1) block */
+        uint32_t prefix = payload >> 11;         /* upper 15 bits */
+        uint16_t info   = payload & 0x7FF;       /* lower 11 bits */
+        uint16_t code   = bch_encode(info);
+        return (prefix << 15) | code;
+    }
+
+    /* fallback: behave like the previous implementation */
     uint32_t word = payload << (30 - bits);
     uint32_t parity = bch1511(payload, bits);
     word |= parity & ((bits==26)?0xF:0xFF);

--- a/nav_words.h
+++ b/nav_words.h
@@ -1,5 +1,10 @@
 #ifndef NAV_WORDS_H
 #define NAV_WORDS_H
 #include <stdint.h>
+/* Construct a 30‑bit navigation word following the BeiDou ICD.
+ * For bits == 26 the upper 15 bits are transmitted directly and the
+ * lower 11 bits are BCH encoded.  For bits == 22 two 11‑bit groups are
+ * BCH encoded and interleaved bit by bit.
+ */
 uint32_t build_word(uint32_t payload, int bits);
 #endif

--- a/navbits.c
+++ b/navbits.c
@@ -24,8 +24,9 @@ static void build_subframe1(uint8_t *out, const ephemeris_t *e,
     memset(out,0,SF_STREAM_LEN);
 
     /* word1：帧同步 11 bits（11100010010） + FraID(001) + SOW[19:12] */
-    uint16_t info = 0x712;            /* 11100010010 */
-    info = ((info << 3)|0x1) & 0x7FF; /* +FraID=001 */
+    uint32_t info = 0x712;            /* 11-bit preamble */
+    info = (info << 4);               /* reserved bits */
+    info = (info << 3) | 0x1;         /* FraID=001 */
     /*
      * SOW should reflect the start time of this subframe.
      * According to the B1I ICD section 5.2.4.3 the value
@@ -67,9 +68,10 @@ static void build_subframe2(uint8_t *out, const ephemeris_t *e)
     memset(out,0,SF_STREAM_LEN);
 
     /* word1: FrameSync + FraID=010 + toe[15:8] */
-    uint16_t info = 0x712;            /* sync */
-    info = ((info<<3)|0x2) & 0x7FF;   /* FraID=010 */
-    info = (info<<8) | ((uint32_t)e->toe>>8 &0xFF);
+    uint32_t info = 0x712;            /* preamble */
+    info = (info << 4);               /* reserved */
+    info = (info << 3) | 0x2;         /* FraID=010 */
+    info = (info << 8) | ((uint32_t)e->toe>>8 &0xFF);
     put_word(out,0, build_word(info, 26));
 
     /* word2: toe[7:0] + √A[21:13] */
@@ -101,8 +103,9 @@ static void build_subframe3(uint8_t *out, const ephemeris_t *e)
     memset(out,0,SF_STREAM_LEN);
 
     /* word1 : sync + FraID=011 + Ω0[21:14] */
-    uint16_t info = 0x712;
-    info = ((info<<3)|0x3) & 0x7FF;
+    uint32_t info = 0x712;            /* preamble */
+    info = (info << 4);
+    info = (info << 3) | 0x3;         /* FraID=011 */
     int32_t O0_i = (int32_t)llround(e->omega0 / pow(2,-31));
     info = (info<<8) | ((O0_i>>14)&0xFF);
     put_word(out,0, build_word(info, 26));
@@ -147,8 +150,9 @@ static void build_subframe4(uint8_t *out,int week,double sow,double frame_len)
 
 {
     memset(out,0,SF_STREAM_LEN);
-    uint16_t info = 0x712;            /* sync */
-    info = ((info<<3)|0x4) & 0x7FF;   /* FraID=100 */
+    uint32_t info = 0x712;            /* preamble */
+    info = (info << 4);
+    info = (info << 3) | 0x4;         /* FraID=100 */
 
     uint32_t sow_int = (uint32_t)(floor(sow/frame_len)*frame_len);
     info = (info<<8) | ((sow_int>>12) & 0xFF);
@@ -165,8 +169,9 @@ static void build_subframe5(uint8_t *out,int week,double sow,double frame_len)
 
 {
     memset(out,0,SF_STREAM_LEN);
-    uint16_t info = 0x712;            /* sync */
-    info = ((info<<3)|0x5) & 0x7FF;   /* FraID=101 */
+    uint32_t info = 0x712;            /* preamble */
+    info = (info << 4);
+    info = (info << 3) | 0x5;         /* FraID=101 */
 
     uint32_t sow_int = (uint32_t)(floor(sow/frame_len)*frame_len);
     info = (info<<8) | ((sow_int>>12) & 0xFF);


### PR DESCRIPTION
## Summary
- build word headers using reserved and FraID bits explicitly
- keep preamble intact before appending SOW bits
- clean up static binary after tests

## Testing
- `make -j4`
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_686fb2c6b2a88327b230f63ec0c6797f