### PR TITLE
Update PRN test to show first 16 bits

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ make
 ```
 
 The optional command `make prn_test` builds a small utility that prints
-the first chips of PRN codes using the bundled RINEX file.
+each PRN number and the first 16 bits of its code in binary using the
+bundled RINEX file.
 
 Run `make check` to build and execute the self test
 (`tests/test_prn_d1d2`).

--- a/prn_test.c
+++ b/prn_test.c
@@ -1,14 +1,21 @@
 #include <stdio.h>
 #include "bdssim.h"
+
 int main(void){
     sim_config_t c = {0};
     /* Use bundled RINEX file for demonstration */
     snprintf(c.rinex_file, sizeof(c.rinex_file),
              "BRDM00DLR_S_20251760000_01D_MN.rnx");
     init_simulator(&c);
-    puts("PRN01 前 32 chip:");
-    for(int i=0;i<32;i++) printf("%d",prn_code[1][i]);
-    puts(""); return 0;
+
+    for(int prn=1; prn<=63; ++prn){
+        printf("PRN%02d:", prn);
+        for(int i=0;i<16;i++)
+            printf("%d", prn_code[prn][i]);
+        putchar('\n');
+    }
+    cleanup_simulator();
+    return 0;
 }
 
 


### PR DESCRIPTION
## Summary
- refine `prn_test` to print the first 16 bits of each PRN code
- update the README to describe the new behavior

## Testing
- `make prn_test`
- `make check`
- `./prn_test | head`

------
https://chatgpt.com/codex/tasks/task_e_6873aa948f788327a541e201a1b6177a