### PR TITLE
Fix PRN table build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 bds-sim
 prn_test
 test_beidou
+tests/test_prn_d1d2
 *.bin
 *.gz
 cookies.txt

--- a/globals.c
+++ b/globals.c
@@ -22,9 +22,10 @@ int simulator_inited = 0;
 /* ───────────── Gold 2046 產生 ───────────── */
 #define G_INIT 0x2AA
 #define MASK11 0x7FF
+/* Bit tap from an LFSR register */
+static inline uint8_t tap(const uint16_t r, uint8_t t){ return (r>>(11 - t)) & 1; }
 static inline uint8_t fb_g1(uint16_t r){ return tap(r, 1) ^ tap(r, 5) ^ tap(r, 6) ^ tap(r, 7) ^ tap(r,10) ^ tap(r,11); }
 static inline uint8_t fb_g2(uint16_t r){ return tap(r, 1) ^ tap(r, 2) ^ tap(r, 3) ^ tap(r, 4) ^ tap(r, 5) ^ tap(r, 8) ^ tap(r, 9) ^ tap(r,11); }
-static inline uint8_t tap(const uint16_t r,uint8_t t){ return (r>>(11-t))&1; }
 
 /* 依 3-tap / 2-tap 表，完整 1-63 */
 static const uint8_t tbl[64][3]={


### PR DESCRIPTION
## Summary
- fix compile error in PRN generator by defining `tap()` before use
- ignore the `tests/test_prn_d1d2` test binary

## Testing
- `make clean && make && make prn_test && make check`

------
https://chatgpt.com/codex/tasks/task_e_6873d879794c8327a227de987da72d82