### PR TITLE
Print UTC time in orbit test

### DIFF
--- a/tests/test_orbits.c
+++ b/tests/test_orbits.c
@@ -2,6 +2,17 @@
 #include "../bdssim.h"
 #include "../globals.h"
 #include "../orbits.h"
+#include <time.h>
+
+static void bdt_to_utc(int week, double sow, char *buf, size_t len)
+{
+    const time_t BDT_EPOCH = 1136073600; /* 2006-01-01 00:00:00 UTC */
+    double sec = week * 604800.0 + sow;  /* BDT seconds since epoch */
+    time_t t = (time_t)(BDT_EPOCH - 14 + sec); /* UTC epoch time */
+    struct tm tm;
+    gmtime_r(&t, &tm);
+    strftime(buf, len, "%Y/%m/%d,%H:%M:%S", &tm);
+}
 
 int main(void)
 {
@@ -14,12 +25,14 @@ int main(void)
     }
 
     double sow = nav_time_min - nav_week*604800.0;
+    char utc[32];
+    bdt_to_utc(nav_week, sow, utc, sizeof utc);
     for(int prn=1; prn<=63; ++prn){
         if(eph[prn].prn==0) continue;
         double xyz[3];
         calc_sat_position_velocity(prn, nav_week, sow, xyz, NULL);
-        printf("PRN%02d @ W%d %.1f -> X %.3f Y %.3f Z %.3f\n",
-               prn, nav_week, sow, xyz[0], xyz[1], xyz[2]);
+        printf("PRN%02d @ %s -> X %.3f Y %.3f Z %.3f\n",
+               prn, utc, xyz[0], xyz[1], xyz[2]);
     }
 
     cleanup_simulator();


### PR DESCRIPTION
## Summary
- add `bdt_to_utc` helper in `tests/test_orbits.c`
- display UTC instead of BDT week/SOW

## Testing
- `make check`
- `./tests/test_orbits | head`

------
https://chatgpt.com/codex/tasks/task_e_6874e2310f348327b3566ffb880156a1