### PR TITLE
Implement explicit BCH helpers

### DIFF
--- a/bch.c
+++ b/bch.c
@@ -14,18 +14,26 @@ uint16_t bch_encode(uint16_t d11)
     return (d11<<4) | (reg & 0xF);
 }
 
-
-
-/* Generic BCH(15,11,1) encoder returning parity bits for 22 or 26 bit payloads */
-uint32_t bch1511(uint32_t in, int payloadBits)
+/* 對 26 位元資料的後 11 位做 BCH，並在尾端附上 4 位校驗 */
+uint32_t bch_encode_26bit(uint32_t payload)
 {
-    if (payloadBits != 22 && payloadBits != 26)
-        return 0;
-    int parityBits = (payloadBits == 26) ? 4 : 8;
-    uint32_t reg = in << parityBits;  /* space for parity */
-    int top = payloadBits + parityBits - 1;
-    for (int i = top; i >= parityBits; --i)
-        if (reg & (1u << i))
-            reg ^= (uint32_t)G << (i - 4);
-    return reg & ((1u << parityBits) - 1);
+    payload &= 0x3FFFFFF;                 /* 26 bits */
+    uint16_t info = payload & 0x7FF;      /* 取出最後 11 位 */
+    uint16_t parity = bch_encode(info) & 0xF;
+    return (payload << 4) | parity;       /* 26 資料 + 4 校驗 */
+}
+
+/* 將 22 位元資料分成兩組 11 位做 BCH，並交錯輸出 */
+uint32_t bch_interleave_22bit(uint32_t payload)
+{
+    uint16_t high11 = (payload >> 11) & 0x7FF;
+    uint16_t low11  = payload & 0x7FF;
+    uint16_t codeA = bch_encode(high11);
+    uint16_t codeB = bch_encode(low11);
+    uint32_t result = 0;
+    for (int i = 14; i >= 0; --i) {
+        result = (result << 1) | ((codeA >> i) & 1);
+        result = (result << 1) | ((codeB >> i) & 1);
+    }
+    return result;
 }

--- a/bch.h
+++ b/bch.h
@@ -3,7 +3,9 @@
 #include <stdint.h>
 /* 將 11 bit 資訊位編成 15 bit BCH(15,11,1) */
 uint16_t bch_encode(uint16_t info);
-/* 通用 BCH(15,11,1) for longer payloads (22 or 26 bits). */
-uint32_t bch1511(uint32_t in, int payloadBits);
+/* 將 26 位元資料尾端 11 位做 BCH，輸出 30 位 */
+uint32_t bch_encode_26bit(uint32_t payload);
+/* 將兩組 11 位元資料分別 BCH 後交錯成 30 位 */
+uint32_t bch_interleave_22bit(uint32_t payload);
 #endif
 

--- a/nav_words.c
+++ b/nav_words.c
@@ -8,29 +8,9 @@
  */
 uint32_t build_word(uint32_t payload, int bits)
 {
-    if (bits == 22) {
-        /* split into two 11-bit groups and interleave the BCH codes */
-        uint16_t infoA = (payload >> 11) & 0x7FF;
-        uint16_t infoB = payload & 0x7FF;
-        uint16_t codeA = bch_encode(infoA);
-        uint16_t codeB = bch_encode(infoB);
-        uint32_t w = 0;
-        for (int i = 14; i >= 0; --i) {
-            w = (w << 1) | ((codeA >> i) & 1);
-            w = (w << 1) | ((codeB >> i) & 1);
-        }
-        return w;
-    } else if (bits == 26) {
-        /* 15-bit prefix followed by one BCH(15,11,1) block */
-        uint32_t prefix = payload >> 11;         /* upper 15 bits */
-        uint16_t info   = payload & 0x7FF;       /* lower 11 bits */
-        uint16_t code   = bch_encode(info);
-        return (prefix << 15) | code;
-    }
-
-    /* fallback: behave like the previous implementation */
-    uint32_t word = payload << (30 - bits);
-    uint32_t parity = bch1511(payload, bits);
-    word |= parity & ((bits==26)?0xF:0xFF);
-    return word;
+    if (bits == 22)
+        return bch_interleave_22bit(payload);
+    else if (bits == 26)
+        return bch_encode_26bit(payload);
+    return 0;
 }


### PR DESCRIPTION
## Summary
- add helper routines for 26-bit and 22-bit BCH navigation words
- simplify `build_word` using the helpers

## Testing
- `make check`
- `make bds-sim`
- `make tests/test_orbits`
- `./tests/test_prn_d1d2`


------
https://chatgpt.com/codex/tasks/task_e_687e0e4e52cc832783ef4baa10924ecc