### PR TITLE
Add D2 PRN cycle test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ prn_test
 test_beidou
 tests/test_prn_d1d2
 tests/test_orbits
+tests/test_d2_cycles
 *.bin
 *.gz
 cookies.txt
+tests/test_nh_prn

--- a/Makefile
+++ b/Makefile
@@ -14,19 +14,29 @@ prn_test: prn_test.o globals.o bch.o nav_words.o nav_pages.o navbits.o channel.o
 tests/test_prn_d1d2: tests/test_prn_d1d2.o globals.o bch.o nav_words.o nav_pages.o navbits.o channel.o rinex.o orbits.o coord.o path.o bdssim.o
 	$(CC) $(CFLAGS) $^ -o $@ -lm
 
+tests/test_nh_prn: tests/test_nh_prn.o globals.o bch.o nav_words.o nav_pages.o navbits.o channel.o rinex.o orbits.o coord.o path.o bdssim.o
+	$(CC) $(CFLAGS) $^ -o $@ -lm
+
+tests/test_d2_cycles: tests/test_d2_cycles.o globals.o bch.o nav_words.o nav_pages.o navbits.o channel.o rinex.o orbits.o coord.o path.o bdssim.o
+	$(CC) $(CFLAGS) $^ -o $@ -lm
+
 tests/test_orbits: tests/test_orbits.o globals.o bch.o nav_words.o nav_pages.o navbits.o channel.o rinex.o orbits.o coord.o path.o bdssim.o
 	$(CC) $(CFLAGS) $^ -o $@ -lm
 
-check: tests/test_prn_d1d2
+check: tests/test_prn_d1d2 tests/test_nh_prn tests/test_d2_cycles
 	./tests/test_prn_d1d2
+	./tests/test_nh_prn
+	./tests/test_d2_cycles
 
 %.o: %.c
 	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
 	rm -f *.o bds-sim prn_test test_beidou \
-	       tests/test_prn_d1d2 tests/test_prn_d1d2.o \
-	       tests/test_orbits tests/test_orbits.o *.bin *.gz
+	tests/test_prn_d1d2 tests/test_prn_d1d2.o \
+	tests/test_nh_prn tests/test_nh_prn.o \
+	tests/test_d2_cycles tests/test_d2_cycles.o \
+	tests/test_orbits tests/test_orbits.o *.bin *.gz
 	@echo "✅ 已清除中間檔與 .gz 暫存檔"
 
 # =====================[ 下載區 ]=====================

--- a/tests/test_d2_cycles.c
+++ b/tests/test_d2_cycles.c
@@ -1,0 +1,45 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <math.h>
+#include <assert.h>
+#include "../bdssim.h"
+#include "../channel.h"
+#include "../globals.h"
+
+int main(void)
+{
+    sim_config_t cfg = {0};
+    snprintf(cfg.rinex_file, sizeof(cfg.rinex_file),
+             "BRDM00DLR_S_20251760000_01D_MN.rnx");
+    if(!init_simulator(&cfg)){
+        fprintf(stderr, "init failed\n");
+        return 1;
+    }
+
+    int prn = 3; /* GEO uses D2 without NH */
+    channel_t ch;
+    channel_reset(&ch, prn, nav_week, 0.0);
+    ch.carr_phase = 0.0;
+    ch.code_phase = 0.1; /* avoid boundary ambiguity */
+    update_channel_dynamics(&ch, 2.0e7, 0.0, 1.0, cfg.target_cn0);
+    channel_set_fs(5.12e6);
+
+    int samp_per_ms = (int)(5.12e6/1000.0 + 0.5);
+    int16_t I[samp_per_ms], Q[samp_per_ms];
+
+    /* generate 2 ms and verify D2 bit spans two PRN cycles */
+    for(int i=0;i<2;i++){
+        gen_samples_1ms_d2(&ch, nav_week, i*0.001, samp_per_ms, I, Q);
+        if(i==0){
+            assert(ch.ms_count_d2 == 1);
+            assert(ch.bit_ptr_d2 == 0);
+        } else {
+            assert(ch.ms_count_d2 == 0);
+            assert(ch.bit_ptr_d2 == 1);
+        }
+        assert(fabs(ch.code_phase - 0.1) < 1e-6);
+    }
+
+    cleanup_simulator();
+    return 0;
+}

--- a/tests/test_nh_prn.c
+++ b/tests/test_nh_prn.c
@@ -1,0 +1,45 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <math.h>
+#include <assert.h>
+#include "../bdssim.h"
+#include "../channel.h"
+#include "../globals.h"
+
+int main(void)
+{
+    sim_config_t cfg = {0};
+    snprintf(cfg.rinex_file, sizeof(cfg.rinex_file),
+             "BRDM00DLR_S_20251760000_01D_MN.rnx");
+    if(!init_simulator(&cfg)){
+        fprintf(stderr, "init failed\n");
+        return 1;
+    }
+
+    int prn = 8; /* MEO/IGSO uses D1 with NH code */
+    channel_t ch;
+    channel_reset(&ch, prn, nav_week, 0.0);
+    ch.carr_phase = 0.0;
+    ch.code_phase = 0.1; /* avoid boundary ambiguity */
+    update_channel_dynamics(&ch, 2.0e7, 0.0, 1.0, cfg.target_cn0);
+    channel_set_fs(5.12e6);
+
+    int samp_per_ms = (int)(5.12e6/1000.0 + 0.5);
+    int16_t I[samp_per_ms], Q[samp_per_ms];
+
+    /* generate 20 ms and verify NH/PRN relationship */
+    for(int i=0;i<20;i++){
+        gen_samples_1ms(&ch, nav_week, i*0.001, samp_per_ms, I, Q);
+        if(i<19){
+            assert(ch.ms_count == (i+1));
+            assert(ch.bit_ptr == 0);
+        } else {
+            assert(ch.ms_count == 0);
+            assert(ch.bit_ptr == 1);
+        }
+        assert(fabs(ch.code_phase - 0.1) < 1e-6);
+    }
+
+    cleanup_simulator();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add regression test to confirm each D2 nav bit spans two PRN cycles
- build and run the new test via Makefile
- ignore test binary in `.gitignore`

## Testing
- `make clean`
- `make check -k`

------
https://chatgpt.com/codex/tasks/task_e_687f3ac31df08327bd3804ff5e0fb1ad