### PR TITLE
Align navbits frame types with ICD

### DIFF
--- a/icd_fields.h
+++ b/icd_fields.h
@@ -21,8 +21,8 @@ typedef struct {
     /* orbital parameters --------------------------------------- */
     int32_t  delta_n;    /* 16 bits signed */
     int32_t  M0;         /* 32 bits signed */
-    int32_t  e;          /* 32 bits unsigned scaled */
-    int32_t  sqrtA;      /* 32 bits unsigned scaled */
+    uint32_t e;          /* 32 bits unsigned */
+    uint32_t sqrtA;      /* 32 bits unsigned */
     int32_t  cuc;        /* 18 bits signed */
     int32_t  cus;        /* 18 bits signed */
     int32_t  crc;        /* 18 bits signed */

--- a/navbits.c
+++ b/navbits.c
@@ -45,8 +45,8 @@ static void frame_from_ephemeris(const ephemeris_t *e, B1I_D1_Frame *f)
     f->a2       = (int32_t)llround(e->af2 / pow(2, -66));
 
     f->toe      = (uint32_t)(e->toe / 8);
-    f->sqrtA    = (int32_t)llround(e->sqrtA / pow(2, -19));
-    f->e        = (int32_t)llround(e->e / pow(2, -33));
+    f->sqrtA    = (uint32_t)llround(e->sqrtA / pow(2, -19));
+    f->e        = (uint32_t)llround(e->e / pow(2, -33));
     f->delta_n  = (int32_t)llround(e->deltan / pow(2, -43));
     f->M0       = (int32_t)llround(e->M0 / pow(2, -31));
 


### PR DESCRIPTION
## Summary
- mark `e` and `sqrtA` as unsigned in `B1I_D1_Frame`
- store `sqrtA` and `e` as unsigned when converting from ephemeris

## Testing
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_6881bebd92f48327aacb12d1e6b005ef