### PR TITLE
Fix RINEX AODE handling

### DIFF
--- a/bdssim.h
+++ b/bdssim.h
@@ -21,7 +21,7 @@ typedef struct {
     double af0, af1, af2;
 
     /* 其他 RINEX 欄位（暫未使用） */
-    int     iode;            /* line 2 */
+    int     aode;            /* Age of Data, Ephemeris (line 2) */
     int     freq_num;        /* BDS frequency number */
     double  a0utc, a1utc, a2utc;   /* BDT‑UTC 偏移 */
     double  toe_msg;         /* Transmission time of message */

--- a/navbits.c
+++ b/navbits.c
@@ -153,7 +153,7 @@ static void build_subframe1_d1(uint8_t *out, const ephemeris_t *e,
 
     /* word10: a1 low 17 + AODE */
     uint32_t w10 = (((uint32_t)a1_i & 0x1FFFF) << 5) |
-                   (e->iode & 0x1F);
+                   (e->aode & 0x1F);
     put_word(out,270, build_word(w10,22));
 }
 

--- a/rinex.c
+++ b/rinex.c
@@ -125,7 +125,7 @@ int read_rinex_nav(const char *fname)
         for (int i = 0; i < 7; ++i)
             if (!fgets(r[i], sizeof r[i], fp)) return -1;
 
-        e->iode    = ifld(r[0], 0, INDN);
+        e->aode    = ifld(r[0], 0, INDN);
         e->crs     = fld(r[0], 1, INDN);
         e->deltan  = fld(r[0], 2, INDN);
         e->M0      = fld(r[0], 3, INDN);


### PR DESCRIPTION
## Summary
- store Age of Data, Ephemeris (AODE) in `ephemeris_t`
- read AODE from RINEX instead of IODE
- output AODE when building nav bits

## Testing
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_6881c5e90f0883278df4d888ec357050