### PR TITLE
Add time conversion utility test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ tests/test_d2_cycles: tests/test_d2_cycles.o globals.o bch.o navbits.o channel.o
 tests/test_orbits: tests/test_orbits.o globals.o bch.o navbits.o channel.o rinex.o orbits.o coord.o path.o bdssim.o
 	$(CC) $(CFLAGS) $^ -o $@ -lm
 
+tests/test_timeconv: tests/test_timeconv.c
+	$(CC) $(CFLAGS) $< -o $@
+
 check: tests/test_prn_d1d2 tests/test_nh_prn tests/test_d2_cycles
 	./tests/test_prn_d1d2
 	./tests/test_nh_prn
@@ -38,8 +41,9 @@ clean:
 	rm -f *.o bds-sim tests/prn_test tests/test_beidou \
 	tests/test_prn_d1d2 tests/test_prn_d1d2.o \
 	tests/test_nh_prn tests/test_nh_prn.o \
-	tests/test_d2_cycles tests/test_d2_cycles.o \
-	tests/test_orbits tests/test_orbits.o *.bin *.gz
+        tests/test_d2_cycles tests/test_d2_cycles.o \
+        tests/test_orbits tests/test_orbits.o \
+        tests/test_timeconv *.bin *.gz
 	@echo "✅ 已清除中間檔與 .gz 暫存檔"
 
 # =====================[ 下載區 ]=====================

--- a/tests/test_timeconv.c
+++ b/tests/test_timeconv.c
@@ -1,0 +1,33 @@
+#include <stdio.h>
+#include <time.h>
+#include "timeconv.h"
+
+int main(int argc, char *argv[])
+{
+    if (argc != 2) {
+        fprintf(stderr, "Usage: %s YYYY/MM/DD,HH:MM:SS\n", argv[0]);
+        return 1;
+    }
+
+    int week; double sow;
+    if (utc_to_bdt(argv[1], &week, &sow) != 0) {
+        fprintf(stderr, "Invalid UTC format\n");
+        return 1;
+    }
+
+    struct tm tm = {0};
+    if (!strptime(argv[1], "%Y/%m/%d,%H:%M:%S", &tm)) {
+        fprintf(stderr, "Invalid UTC format\n");
+        return 1;
+    }
+    time_t t = timegm(&tm) + 4; /* UTC -> BDT */
+
+    struct tm bdt;
+    gmtime_r(&t, &bdt);
+
+    printf("BDT calendar: %04d/%02d/%02d,%02d:%02d:%02d\n",
+           bdt.tm_year + 1900, bdt.tm_mon + 1, bdt.tm_mday,
+           bdt.tm_hour, bdt.tm_min, bdt.tm_sec);
+    printf("BDT week/sow: %d %.0f\n", week, sow);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add `test_timeconv` utility program
- compile the new test via Makefile
- clean up the binary in `make clean`

## Testing
- `make tests/test_timeconv`
- `./tests/test_timeconv 2025/06/25,00:00:00`
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_6881f1ee81508327ad5f9eadb9459f87