### PR TITLE
Add week/SOW parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ tests/test_d2_cycles
 *.gz
 cookies.txt
 tests/test_nh_prn
+
+tests/test_timeconv

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ tests/test_d2_cycles: tests/test_d2_cycles.o globals.o bch.o navbits.o channel.o
 tests/test_orbits: tests/test_orbits.o globals.o bch.o navbits.o channel.o rinex.o orbits.o coord.o path.o bdssim.o
 	$(CC) $(CFLAGS) $^ -o $@ -lm
 
+tests/test_timeconv: tests/test_timeconv.c
+	$(CC) $(CFLAGS) $< -o $@
+
 check: tests/test_prn_d1d2 tests/test_nh_prn tests/test_d2_cycles
 	./tests/test_prn_d1d2
 	./tests/test_nh_prn
@@ -38,8 +41,9 @@ clean:
 	rm -f *.o bds-sim tests/prn_test tests/test_beidou \
 	tests/test_prn_d1d2 tests/test_prn_d1d2.o \
 	tests/test_nh_prn tests/test_nh_prn.o \
-	tests/test_d2_cycles tests/test_d2_cycles.o \
-	tests/test_orbits tests/test_orbits.o *.bin *.gz
+        tests/test_d2_cycles tests/test_d2_cycles.o \
+        tests/test_orbits tests/test_orbits.o \
+        tests/test_timeconv *.bin *.gz
 	@echo "✅ 已清除中間檔與 .gz 暫存檔"
 
 # =====================[ 下載區 ]=====================

--- a/rinex.c
+++ b/rinex.c
@@ -30,29 +30,6 @@ static int ifld(const char *ln, int idx, int ind)
 }
 
 /* very-tiny, zone-less timegm (UTC→UNIX)  –  只考慮閏年規則，可跨平台 */
-static time_t my_timegm(struct tm *t)
-{
-    static const int days_in_mon[12] =
-        {31,28,31,30,31,30,31,31,30,31,30,31};
-
-    int y = t->tm_year + 1900;
-    int m = t->tm_mon;
-    int d = t->tm_mday - 1;             /* 0-based */
-
-    /*  days since 1970-01-01 */
-    int days = 0;
-    for (int yr = 1970; yr < y; ++yr)
-        days += 365 + ((yr % 4 == 0 && yr % 100) || (yr % 400 == 0));
-    for (int mo = 0; mo < m; ++mo) {
-        days += days_in_mon[mo];
-        if (mo == 1 && ((y % 4 == 0 && y % 100) || (y % 400 == 0)))
-            ++days;                     /* Feb 29 */
-    }
-    days += d;
-
-    return (time_t)days * 86400
-         + t->tm_hour * 3600 + t->tm_min * 60 + t->tm_sec;
-}
 
 /* ---------- 主要解析 ---------- */
 int read_rinex_nav(const char *fname)
@@ -99,26 +76,7 @@ int read_rinex_nav(const char *fname)
         e->af1 = fld(l, 1, IND1);
         e->af2 = fld(l, 2, IND1);
 
-        int Y, M, D, h, m;
-        double s;
-        sscanf(l + 4, "%4d %2d %2d %2d %2d %lf", &Y, &M, &D, &h, &m, &s);
-
-        struct tm utc = {0};
-        utc.tm_year = Y - 1900;  utc.tm_mon  = M - 1;  utc.tm_mday = D;
-        utc.tm_hour = h;         utc.tm_min  = m;      utc.tm_sec  = (int)s;
-
-        time_t unix_t = my_timegm(&utc);
-
-        /* BDT: TAI-32.0 (leap) – 既然 RINEX 是 UTC，需加上 UTC-BDT 偏移 */
-        const time_t BDT_EPOCH = 1136073600;    /* 2006-01-01 00:00:00 UTC */
-        const int    LS_GPS_2025 = 18;          /* leap seconds 到 2025-06 */
-        const int    LS_BDT      = 0;           /* BDT 無閏秒 */
-        int bdt_off = (LS_GPS_2025 - LS_BDT);   /* 一律 18 秒 (現行) */
-
-        time_t bdt_time = unix_t + bdt_off - BDT_EPOCH;
-        e->toc = (int)(bdt_time % 604800);
-        if (e->toc < 0) e->toc += 604800;
-        e->week = (int)(bdt_time / 604800);
+        /* 先略過年月日等欄位，僅取後續週數與 TOE/SOW  */
 
         /* ── 讀後 7 行 -------------------------------------------- */
         char r[7][120];
@@ -136,6 +94,7 @@ int read_rinex_nav(const char *fname)
         e->sqrtA   = fld(r[1], 3, INDN);
 
         e->toe     = fld(r[2], 0, INDN);
+        e->toc     = (int)e->toe;          /* RINEX 無 toc 欄位，沿用 toe */
         e->cic     = fld(r[2], 1, INDN);
         e->omega0  = fld(r[2], 2, INDN);
         e->cis     = fld(r[2], 3, INDN);
@@ -148,7 +107,7 @@ int read_rinex_nav(const char *fname)
         e->idot    = fld(r[4], 0, INDN);
         e->freq_num = ifld(r[4], 1, INDN); /* reserved/freq number */
         int week_r = ifld(r[4], 2, INDN);  /* BDS week number */
-        if (week_r) e->week = week_r;
+        e->week = week_r;
 
         /* line 7: SV accuracy/health and TGD1/2 */
         e->ura     = ifld(r[5], 0, INDN) & 0xF;
@@ -160,7 +119,7 @@ int read_rinex_nav(const char *fname)
         e->toe_msg = fld(r[6], 0, INDN);
         e->aodc    = ifld(r[6], 1, INDN);
 
-        double t_bdt = e->week * 604800.0 + e->toc;
+        double t_bdt = e->week * 604800.0 + e->toe;
         if (t_bdt < nav_time_min) nav_time_min = t_bdt;
         if (t_bdt > nav_time_max) nav_time_max = t_bdt;
     }

--- a/tests/test_timeconv.c
+++ b/tests/test_timeconv.c
@@ -1,0 +1,33 @@
+#include <stdio.h>
+#include <time.h>
+#include "timeconv.h"
+
+int main(int argc, char *argv[])
+{
+    if (argc != 2) {
+        fprintf(stderr, "Usage: %s YYYY/MM/DD,HH:MM:SS\n", argv[0]);
+        return 1;
+    }
+
+    int week; double sow;
+    if (utc_to_bdt(argv[1], &week, &sow) != 0) {
+        fprintf(stderr, "Invalid UTC format\n");
+        return 1;
+    }
+
+    struct tm tm = {0};
+    if (!strptime(argv[1], "%Y/%m/%d,%H:%M:%S", &tm)) {
+        fprintf(stderr, "Invalid UTC format\n");
+        return 1;
+    }
+    time_t t = timegm(&tm) + 4; /* UTC -> BDT */
+
+    struct tm bdt;
+    gmtime_r(&t, &bdt);
+
+    printf("BDT calendar: %04d/%02d/%02d,%02d:%02d:%02d\n",
+           bdt.tm_year + 1900, bdt.tm_mon + 1, bdt.tm_mday,
+           bdt.tm_hour, bdt.tm_min, bdt.tm_sec);
+    printf("BDT week/sow: %d %.0f\n", week, sow);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- parse BeiDou ephemeris using week number and TOE only
- drop unused `my_timegm` helper
- ignore `test_timeconv` binary in git

## Testing
- `make tests/test_timeconv`
- `./tests/test_timeconv 2025/06/25,00:00:00`
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_6881f1ee81508327ad5f9eadb9459f87