### PR TITLE
Add ephemeris selection by start time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ tests/test_d2_cycles
 *.gz
 cookies.txt
 tests/test_nh_prn
+
+tests/test_timeconv

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ tests/test_d2_cycles: tests/test_d2_cycles.o globals.o bch.o navbits.o channel.o
 tests/test_orbits: tests/test_orbits.o globals.o bch.o navbits.o channel.o rinex.o orbits.o coord.o path.o bdssim.o
 	$(CC) $(CFLAGS) $^ -o $@ -lm
 
+tests/test_timeconv: tests/test_timeconv.c
+	$(CC) $(CFLAGS) $< -o $@
+
 check: tests/test_prn_d1d2 tests/test_nh_prn tests/test_d2_cycles
 	./tests/test_prn_d1d2
 	./tests/test_nh_prn
@@ -38,8 +41,9 @@ clean:
 	rm -f *.o bds-sim tests/prn_test tests/test_beidou \
 	tests/test_prn_d1d2 tests/test_prn_d1d2.o \
 	tests/test_nh_prn tests/test_nh_prn.o \
-	tests/test_d2_cycles tests/test_d2_cycles.o \
-	tests/test_orbits tests/test_orbits.o *.bin *.gz
+        tests/test_d2_cycles tests/test_d2_cycles.o \
+        tests/test_orbits tests/test_orbits.o \
+        tests/test_timeconv *.bin *.gz
 	@echo "✅ 已清除中間檔與 .gz 暫存檔"
 
 # =====================[ 下載區 ]=====================

--- a/bdssim.c
+++ b/bdssim.c
@@ -86,7 +86,7 @@ int select_channels(channel_t *ch,int *n,const coord_t*u)
         double sat[3],vel[3];
         calc_sat_position_velocity(prn,u->week,u->sow,sat,vel);
         double enu[3]; ecef2enu(u,sat,enu);
-        double el=enu_elevation_deg(enu); if(el<10)continue;
+        double el=enu_elevation_deg(enu); if(el<5.0)continue;
         double dx=sat[0]-u->xyz[0], dy=sat[1]-u->xyz[1], dz=sat[2]-u->xyz[2];
         double rho=hypot(hypot(dx,dy),dz);
         double rdot=(dx*(vel[0]-uv[0]) + dy*(vel[1]-uv[1]) + dz*(vel[2]-uv[2]))/rho;
@@ -113,7 +113,7 @@ static void update_channels_dynamic(channel_t *ch,int *n,const coord_t *u,
         double sat[3],vel[3];
         calc_sat_position_velocity(prn,u->week,u->sow,sat,vel);
         double enu[3]; ecef2enu(u,sat,enu);
-        double el=enu_elevation_deg(enu); if(el<10.0) continue;
+        double el=enu_elevation_deg(enu); if(el<5.0) continue;
         double dx=sat[0]-u->xyz[0], dy=sat[1]-u->xyz[1], dz=sat[2]-u->xyz[2];
         double rho=hypot(hypot(dx,dy),dz);
         double rdot=(dx*(vel[0]-uv[0]) + dy*(vel[1]-uv[1]) + dz*(vel[2]-uv[2]))/rho;

--- a/bdssim.h
+++ b/bdssim.h
@@ -60,7 +60,7 @@ typedef struct {
 } sim_config_t;
 
 /* ---------- 介面 ---------- */
-bool  init_simulator(sim_config_t *);
+bool  init_simulator(sim_config_t *, double start_bdt);
 void  generate_signal(const sim_config_t *cfg);   /* ← 加上 const */
 void  cleanup_simulator(void);
 /* 讓 main 可以先做一次 select_channels() 取得 PRN 清單 */

--- a/globals.c
+++ b/globals.c
@@ -85,12 +85,12 @@ static void init_prn_table(void)
 }
 
 /* ───────────── 對外 API ───────────── */
-bool init_simulator(sim_config_t *cfg)
+bool init_simulator(sim_config_t *cfg, double start_bdt)
 {
     if(simulator_inited) return true;
     init_prn_table();
     memset(eph, 0, sizeof(eph));
-    if(read_rinex_nav(cfg->rinex_file)!=0) return false;
+    if(read_rinex_nav(cfg->rinex_file, start_bdt)!=0) return false;
     nav_week = (int)(nav_time_min/604800.0);
     simulator_inited = 1;
     return true;

--- a/main.c
+++ b/main.c
@@ -160,19 +160,20 @@ int main(int argc,char *argv[])
 
 
 
-    /* 3. 初始化 ------------------------------------- */
-    if(!init_simulator(&cfg)){
-        fprintf(stderr,"初始化失敗\n");
-        return 1;
-    }
-
-    /* -- start 時間檢查：必須在星曆區間 h-1 ~ h+1 內 -- */
     int start_week; double start_sow;
     if(utc_to_bdt(cfg.time_start, &start_week, &start_sow)!=0){
         fputs("--start 格式錯誤\n", stderr);
         return 1;
     }
     double start_bdt = start_week*604800.0 + start_sow;
+
+    /* 3. 初始化 ------------------------------------- */
+    if(!init_simulator(&cfg, start_bdt)){
+        fprintf(stderr,"初始化失敗\n");
+        return 1;
+    }
+
+    /* -- start 時間檢查：必須在星曆區間 h-1 ~ h+1 內 -- */
     if(start_bdt < nav_time_min - 3600.0 ||
        start_bdt + cfg.duration > nav_time_max + 86400.0){
         fputs("--start 超出星曆可用區間\n", stderr);

--- a/rinex.c
+++ b/rinex.c
@@ -7,6 +7,7 @@
 #include <string.h>
 #include <ctype.h>
 #include <time.h>
+#include <math.h>
 #include "bdssim.h"
 #include "globals.h"
 
@@ -30,32 +31,9 @@ static int ifld(const char *ln, int idx, int ind)
 }
 
 /* very-tiny, zone-less timegm (UTC→UNIX)  –  只考慮閏年規則，可跨平台 */
-static time_t my_timegm(struct tm *t)
-{
-    static const int days_in_mon[12] =
-        {31,28,31,30,31,30,31,31,30,31,30,31};
-
-    int y = t->tm_year + 1900;
-    int m = t->tm_mon;
-    int d = t->tm_mday - 1;             /* 0-based */
-
-    /*  days since 1970-01-01 */
-    int days = 0;
-    for (int yr = 1970; yr < y; ++yr)
-        days += 365 + ((yr % 4 == 0 && yr % 100) || (yr % 400 == 0));
-    for (int mo = 0; mo < m; ++mo) {
-        days += days_in_mon[mo];
-        if (mo == 1 && ((y % 4 == 0 && y % 100) || (y % 400 == 0)))
-            ++days;                     /* Feb 29 */
-    }
-    days += d;
-
-    return (time_t)days * 86400
-         + t->tm_hour * 3600 + t->tm_min * 60 + t->tm_sec;
-}
 
 /* ---------- 主要解析 ---------- */
-int read_rinex_nav(const char *fname)
+int read_rinex_nav(const char *fname, double start_bdt)
 {
     FILE *fp = fopen(fname, "r");
     if (!fp) { perror(fname);  return -1; }
@@ -71,6 +49,8 @@ int read_rinex_nav(const char *fname)
 
     nav_time_min = 1e20;
     nav_time_max = -1e20;
+    double best_diff[MAX_SAT];
+    for(int i=0;i<MAX_SAT;i++) best_diff[i]=1e20;
 
     while (fgets(l, sizeof(l), fp))
     {
@@ -85,84 +65,66 @@ int read_rinex_nav(const char *fname)
             continue;
         }
 
-        ephemeris_t *e = &eph[prn];
-        if(e->prn){
-            char skip[120];
-            for(int i=0;i<7;++i) if(!fgets(skip,sizeof skip,fp)) return -1;
-            continue;                       /* keep first record only */
-        }
-        memset(e, 0, sizeof(*e));
-        e->prn = prn;
+        ephemeris_t tmp = {0};
+        tmp.prn = prn;
 
         /* ── 1st row：af0/1/2 & UTC stamp -------------------------- */
-        e->af0 = fld(l, 0, IND1);
-        e->af1 = fld(l, 1, IND1);
-        e->af2 = fld(l, 2, IND1);
+        tmp.af0 = fld(l, 0, IND1);
+        tmp.af1 = fld(l, 1, IND1);
+        tmp.af2 = fld(l, 2, IND1);
 
-        int Y, M, D, h, m;
-        double s;
-        sscanf(l + 4, "%4d %2d %2d %2d %2d %lf", &Y, &M, &D, &h, &m, &s);
-
-        struct tm utc = {0};
-        utc.tm_year = Y - 1900;  utc.tm_mon  = M - 1;  utc.tm_mday = D;
-        utc.tm_hour = h;         utc.tm_min  = m;      utc.tm_sec  = (int)s;
-
-        time_t unix_t = my_timegm(&utc);
-
-        /* BDT: TAI-32.0 (leap) – 既然 RINEX 是 UTC，需加上 UTC-BDT 偏移 */
-        const time_t BDT_EPOCH = 1136073600;    /* 2006-01-01 00:00:00 UTC */
-        const int    LS_GPS_2025 = 18;          /* leap seconds 到 2025-06 */
-        const int    LS_BDT      = 0;           /* BDT 無閏秒 */
-        int bdt_off = (LS_GPS_2025 - LS_BDT);   /* 一律 18 秒 (現行) */
-
-        time_t bdt_time = unix_t + bdt_off - BDT_EPOCH;
-        e->toc = (int)(bdt_time % 604800);
-        if (e->toc < 0) e->toc += 604800;
-        e->week = (int)(bdt_time / 604800);
+        /* 先略過年月日等欄位，僅取後續週數與 TOE/SOW  */
 
         /* ── 讀後 7 行 -------------------------------------------- */
         char r[7][120];
         for (int i = 0; i < 7; ++i)
             if (!fgets(r[i], sizeof r[i], fp)) return -1;
 
-        e->aode    = ifld(r[0], 0, INDN);
-        e->crs     = fld(r[0], 1, INDN);
-        e->deltan  = fld(r[0], 2, INDN);
-        e->M0      = fld(r[0], 3, INDN);
+        tmp.aode    = ifld(r[0], 0, INDN);
+        tmp.crs     = fld(r[0], 1, INDN);
+        tmp.deltan  = fld(r[0], 2, INDN);
+        tmp.M0      = fld(r[0], 3, INDN);
 
-        e->cuc     = fld(r[1], 0, INDN);
-        e->e       = fld(r[1], 1, INDN);
-        e->cus     = fld(r[1], 2, INDN);
-        e->sqrtA   = fld(r[1], 3, INDN);
+        tmp.cuc     = fld(r[1], 0, INDN);
+        tmp.e       = fld(r[1], 1, INDN);
+        tmp.cus     = fld(r[1], 2, INDN);
+        tmp.sqrtA   = fld(r[1], 3, INDN);
 
-        e->toe     = fld(r[2], 0, INDN);
-        e->cic     = fld(r[2], 1, INDN);
-        e->omega0  = fld(r[2], 2, INDN);
-        e->cis     = fld(r[2], 3, INDN);
+        tmp.toe     = fld(r[2], 0, INDN);
+        tmp.toc     = (int)tmp.toe;          /* RINEX 無 toc 欄位，沿用 toe */
+        tmp.cic     = fld(r[2], 1, INDN);
+        tmp.omega0  = fld(r[2], 2, INDN);
+        tmp.cis     = fld(r[2], 3, INDN);
 
-        e->i0      = fld(r[3], 0, INDN);
-        e->crc     = fld(r[3], 1, INDN);
-        e->w       = fld(r[3], 2, INDN);
-        e->omegadot= fld(r[3], 3, INDN);
+        tmp.i0      = fld(r[3], 0, INDN);
+        tmp.crc     = fld(r[3], 1, INDN);
+        tmp.w       = fld(r[3], 2, INDN);
+        tmp.omegadot= fld(r[3], 3, INDN);
 
-        e->idot    = fld(r[4], 0, INDN);
-        e->freq_num = ifld(r[4], 1, INDN); /* reserved/freq number */
+        tmp.idot    = fld(r[4], 0, INDN);
+        tmp.freq_num = ifld(r[4], 1, INDN); /* reserved/freq number */
         int week_r = ifld(r[4], 2, INDN);  /* BDS week number */
-        if (week_r) e->week = week_r;
+        tmp.week = week_r;
 
         /* line 7: SV accuracy/health and TGD1/2 */
-        e->ura     = ifld(r[5], 0, INDN) & 0xF;
-        e->health  = ifld(r[5], 1, INDN) & 0x1;
-        e->tgd1    = fld(r[5], 2, INDN);
-        e->tgd2    = fld(r[5], 3, INDN);
+        tmp.ura     = ifld(r[5], 0, INDN) & 0xF;
+        tmp.health  = ifld(r[5], 1, INDN) & 0x1;
+        tmp.tgd1    = fld(r[5], 2, INDN);
+        tmp.tgd2    = fld(r[5], 3, INDN);
 
         /* line 8: transmission time of message and AODC */
-        e->toe_msg = fld(r[6], 0, INDN);
-        e->aodc    = ifld(r[6], 1, INDN);
+        tmp.toe_msg = fld(r[6], 0, INDN);
+        tmp.aodc    = ifld(r[6], 1, INDN);
 
-        double t_bdt = e->week * 604800.0 + e->toc;
+        double t_bdt = tmp.week * 604800.0 + tmp.toe;
         if (t_bdt < nav_time_min) nav_time_min = t_bdt;
         if (t_bdt > nav_time_max) nav_time_max = t_bdt;
+
+        double diff = fabs(t_bdt - start_bdt);
+        if(diff < best_diff[prn]){
+            best_diff[prn] = diff;
+            eph[prn] = tmp;
+        }
     }
 
     fclose(fp);

--- a/rinex.h
+++ b/rinex.h
@@ -1,6 +1,6 @@
 #ifndef RINEX_H
 #define RINEX_H
-int read_rinex_nav(const char *file);
+int read_rinex_nav(const char *file, double start_bdt);
 #endif
 
 

--- a/tests/prn_test.c
+++ b/tests/prn_test.c
@@ -6,7 +6,7 @@ int main(void){
     /* Use bundled RINEX file for demonstration */
     snprintf(c.rinex_file, sizeof(c.rinex_file),
              "BRDM00DLR_S_20251760000_01D_MN.rnx");
-    init_simulator(&c);
+    init_simulator(&c, 0.0);
 
     for(int prn=1; prn<=63; ++prn){
         printf("PRN%02d:", prn);

--- a/tests/test_d2_cycles.c
+++ b/tests/test_d2_cycles.c
@@ -11,7 +11,7 @@ int main(void)
     sim_config_t cfg = {0};
     snprintf(cfg.rinex_file, sizeof(cfg.rinex_file),
              "BRDM00DLR_S_20251760000_01D_MN.rnx");
-    if(!init_simulator(&cfg)){
+    if(!init_simulator(&cfg, 0.0)){
         fprintf(stderr, "init failed\n");
         return 1;
     }

--- a/tests/test_nh_prn.c
+++ b/tests/test_nh_prn.c
@@ -11,7 +11,7 @@ int main(void)
     sim_config_t cfg = {0};
     snprintf(cfg.rinex_file, sizeof(cfg.rinex_file),
              "BRDM00DLR_S_20251760000_01D_MN.rnx");
-    if(!init_simulator(&cfg)){
+    if(!init_simulator(&cfg, 0.0)){
         fprintf(stderr, "init failed\n");
         return 1;
     }

--- a/tests/test_orbits.c
+++ b/tests/test_orbits.c
@@ -39,7 +39,7 @@ int main(void)
     sim_config_t cfg = {0};
     snprintf(cfg.rinex_file, sizeof(cfg.rinex_file),
              "BRDM00DLR_S_20251760000_01D_MN.rnx");
-    if(!init_simulator(&cfg)){
+    if(!init_simulator(&cfg, 0.0)){
         fprintf(stderr, "init failed\n");
         return 1;
     }

--- a/tests/test_prn_d1d2.c
+++ b/tests/test_prn_d1d2.c
@@ -9,7 +9,7 @@ int main(void){
     sim_config_t cfg = {0};
     snprintf(cfg.rinex_file, sizeof(cfg.rinex_file),
              "BRDM00DLR_S_20251760000_01D_MN.rnx");
-    if(!init_simulator(&cfg)){
+    if(!init_simulator(&cfg, 0.0)){
         fprintf(stderr, "init failed\n");
         return 1;
     }

--- a/tests/test_timeconv.c
+++ b/tests/test_timeconv.c
@@ -1,0 +1,33 @@
+#include <stdio.h>
+#include <time.h>
+#include "timeconv.h"
+
+int main(int argc, char *argv[])
+{
+    if (argc != 2) {
+        fprintf(stderr, "Usage: %s YYYY/MM/DD,HH:MM:SS\n", argv[0]);
+        return 1;
+    }
+
+    int week; double sow;
+    if (utc_to_bdt(argv[1], &week, &sow) != 0) {
+        fprintf(stderr, "Invalid UTC format\n");
+        return 1;
+    }
+
+    struct tm tm = {0};
+    if (!strptime(argv[1], "%Y/%m/%d,%H:%M:%S", &tm)) {
+        fprintf(stderr, "Invalid UTC format\n");
+        return 1;
+    }
+    time_t t = timegm(&tm) + 4; /* UTC -> BDT */
+
+    struct tm bdt;
+    gmtime_r(&t, &bdt);
+
+    printf("BDT calendar: %04d/%02d/%02d,%02d:%02d:%02d\n",
+           bdt.tm_year + 1900, bdt.tm_mon + 1, bdt.tm_mday,
+           bdt.tm_hour, bdt.tm_min, bdt.tm_sec);
+    printf("BDT week/sow: %d %.0f\n", week, sow);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- choose the ephemeris record closest to the user-supplied start time
- convert start time before initialising simulator
- lower satellite elevation mask to 5 degrees
- adjust tests for new `init_simulator` signature

## Testing
- `make check`
- `make tests/test_timeconv`
- `./tests/test_timeconv 2025/06/25,00:00:00`


------
https://chatgpt.com/codex/tasks/task_e_6881f1ee81508327ad5f9eadb9459f87