### PR TITLE
Add header parsing for ionospheric data

### DIFF
--- a/globals.c
+++ b/globals.c
@@ -16,6 +16,9 @@ ephemeris_t  eph[MAX_SAT];                  /* ★ 真正配置記憶體 ★ */
 double nav_time_min = 0.0;
 double nav_time_max = 0.0;
 int    nav_week     = 0;
+double iono_alpha[4] = {0};
+double iono_beta[4]  = {0};
+int    utc_bdt_diff  = 14;  /* default UTC->BDT offset */
 
 int simulator_inited = 0;
 

--- a/globals.h
+++ b/globals.h
@@ -11,6 +11,9 @@ extern int          simulator_inited;
 extern double       nav_time_min;
 extern double       nav_time_max;
 extern int          nav_week;       /* ephemeris week reference */
+extern double       iono_alpha[4];  /* ionospheric parameters */
+extern double       iono_beta[4];
+extern int          utc_bdt_diff;   /* UTC->BDT offset seconds */
 
 #endif
 

--- a/navbits.c
+++ b/navbits.c
@@ -22,6 +22,9 @@ extern ephemeris_t eph[MAX_SAT];
 /* Convert ephemeris_t to the simplified B1I_D1_Frame structure.
  * Only the fields needed for navigation message assembly are
  * populated here. */
+extern double iono_alpha[4];
+extern double iono_beta[4];
+
 static void frame_from_ephemeris(const ephemeris_t *e, B1I_D1_Frame *f)
 {
     memset(f, 0, sizeof(*f));
@@ -34,10 +37,17 @@ static void frame_from_ephemeris(const ephemeris_t *e, B1I_D1_Frame *f)
     f->tgd1     = (int32_t)llround(e->tgd1 / 1e-10);
     f->tgd2     = (int32_t)llround(e->tgd2 / 1e-10);
 
-    /* Ionospheric parameters not parsed – leave as zero */
+    /* Ionospheric parameters from header.  Each coefficient uses
+     * a different scaling factor according to the B1I ICD. */
+    static const double a_scale[4] = {
+        pow(2, -30), pow(2, -27), pow(2, -24), pow(2, -24)
+    };
+    static const double b_scale[4] = {
+        pow(2, 11), pow(2, 14), pow(2, 16), pow(2, 16)
+    };
     for (int i = 0; i < 4; ++i) {
-        f->alpha[i] = 0;
-        f->beta[i]  = 0;
+        f->alpha[i] = (int32_t)llround(iono_alpha[i] / a_scale[i]);
+        f->beta[i]  = (int32_t)llround(iono_beta[i]  / b_scale[i]);
     }
 
     f->a0       = (int32_t)llround(e->af0 / pow(2, -33));

--- a/rinex.c
+++ b/rinex.c
@@ -40,9 +40,27 @@ int read_rinex_nav(const char *fname, double start_bdt)
 
     char l[120];
 
-    /* skip header --------------------------------------------------- */
+    /* parse header -------------------------------------------------- */
     while (fgets(l, sizeof(l), fp))
+    {
+        if(strncmp(l,"BDSA",4)==0){
+            sscanf(l+4, "%lf %lf %lf %lf", &iono_alpha[0], &iono_alpha[1],
+                   &iono_alpha[2], &iono_alpha[3]);
+            continue;
+        }
+        if(strncmp(l,"BDSB",4)==0){
+            sscanf(l+4, "%lf %lf %lf %lf", &iono_beta[0], &iono_beta[1],
+                   &iono_beta[2], &iono_beta[3]);
+            continue;
+        }
+        if(strncmp(l,"BDUT",4)==0){
+            double a0,a1; int off;
+            if(sscanf(l+4, "%lf %lf %d", &a0, &a1, &off)==3)
+                utc_bdt_diff = off;
+            continue;
+        }
         if (strstr(l, "END OF HEADER")) break;
+    }
 
     const int IND1 = 23;   /* 第一行 offset */
     const int INDN = 4;    /* 後 7 行 offset */

--- a/tests/test_timeconv.c
+++ b/tests/test_timeconv.c
@@ -2,6 +2,8 @@
 #include <time.h>
 #include "timeconv.h"
 
+int utc_bdt_diff = 14;
+
 int main(int argc, char *argv[])
 {
     if (argc != 2) {
@@ -20,7 +22,8 @@ int main(int argc, char *argv[])
         fprintf(stderr, "Invalid UTC format\n");
         return 1;
     }
-    time_t t = timegm(&tm) + 4; /* UTC -> BDT */
+    extern int utc_bdt_diff;
+    time_t t = timegm(&tm) + utc_bdt_diff; /* UTC -> BDT */
 
     struct tm bdt;
     gmtime_r(&t, &bdt);

--- a/timeconv.h
+++ b/timeconv.h
@@ -24,9 +24,9 @@ static inline int utc_to_bdt(const char *utc_str, int *week, double *sow)
 
     time_t t = timegm(&tm);          /* UTC → Unix epoch */
     const time_t bdt0 = 1136073600;  /* 2006-01-01 00:00:00 UTC */
-    /* BDT 比 UTC 快 4 秒 */
+    extern int utc_bdt_diff;
     const time_t week_sec = 604800;
-    time_t diff = t - bdt0 + 4;
+    time_t diff = t - bdt0 + utc_bdt_diff;
 
     long w = diff / week_sec;
     long r = diff % week_sec;


### PR DESCRIPTION
## Summary
- extract BDSA/BDSB/BDUT fields from RINEX header
- store ionospheric parameters and UTC–BDT offset globally
- apply alpha/beta data when building subframe 1
- use variable UTC–BDT difference for time conversion
- fix scaling factors for alpha0-3 and beta0-3

## Testing
- `make check`
- `gcc -I. -O2 -Wall -Wextra -fopenmp -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE tests/test_timeconv.c -o tests/test_timeconv && ./tests/test_timeconv 2025/01/01,00:00:00`


------
https://chatgpt.com/codex/tasks/task_e_688329e2e1ec83278a6a7aef58a2f298