### PR TITLE
Implement subframe 4/5 page numbering

### DIFF
--- a/docs/frame_layout.md
+++ b/docs/frame_layout.md
@@ -22,7 +22,7 @@ Superframe (12 min)
          └─ 10 Words (30 b)
 ```
 
-Subframe 1–3 carry each satellite's ephemeris and clock parameters and repeat every 30 s. Subframes 4 and 5 contain almanac pages, health data and UTC parameters. The page number (PNUM) for subframe 4/5 is located at bits 44–50. The simulator currently outputs a repeating `0x2AAAAA` pattern for these payload words to preserve the layout while omitting the actual almanac data.
+Subframe 1–3 carry each satellite's ephemeris and clock parameters and repeat every 30 s. Subframes 4 and 5 contain almanac pages, health data and UTC parameters. The page number (PNUM) for subframe 4/5 is located at bits 44–50. The simulator cycles this field from 1–24 while keeping the remaining payload words filled with the official `0x2AAAAA` placeholder pattern.
 
 ## D2 Frame Layout
 

--- a/navbits.c
+++ b/navbits.c
@@ -271,6 +271,17 @@ static void build_subframe3_d1(const B1I_D1_Frame *f, uint32_t sow, uint32_t w[1
 }
 
 /* --------------------------------- 子帧 4 ----------------------------------- */
+/* Determine page number (PNUM) based on the current frame index.
+ * The BeiDou superframe contains 24 frames (30 s each) and subframes 4/5
+ * share the same page number within a frame.  Since the simulator does not
+ * implement actual almanac content yet, we simply cycle the value 1–24.
+ */
+static int calc_pnum(double sow, double frame_len)
+{
+    int frame = (int)floor(sow / (frame_len * 5.0));
+    return frame % 24 + 1;
+}
+
 static void build_subframe4_d1(uint8_t *out, int week, double sow,
                                double frame_len)
 {
@@ -292,7 +303,9 @@ static void build_subframe4_d1(uint8_t *out, int week, double sow,
     put_word(out, 0, build_word(w, 26));
 
     /* word2: SOW[11:0] + reserved + PNUM + spare (1,0) */
-    uint32_t w2 = ((sow_int & 0xFFF) << 10) | (0 << 9) | (0 << 2) | 0x2;
+    int pnum = calc_pnum(sow, frame_len);
+    uint32_t w2 = ((sow_int & 0xFFF) << 10) | (0 << 9) |
+                  ((pnum & 0x7F) << 2) | 0x2;
     put_word(out, 30, build_word(w2, 22));
 
     uint32_t filler = 0x2AAAAA; /* 1010... repeated */
@@ -320,7 +333,9 @@ static void build_subframe5_d1(uint8_t *out, int week, double sow,
     put_word(out, 0, build_word(w, 26));
 
     /* word2: SOW[11:0] + reserved + PNUM + spare (1,0) */
-    uint32_t w2 = ((sow_int & 0xFFF) << 10) | (0 << 9) | (0 << 2) | 0x2;
+    int pnum = calc_pnum(sow, frame_len);
+    uint32_t w2 = ((sow_int & 0xFFF) << 10) | (0 << 9) |
+                  ((pnum & 0x7F) << 2) | 0x2;
     put_word(out, 30, build_word(w2, 22));
 
     uint32_t filler = 0x2AAAAA;

--- a/tests/test_pnum_cycle.c
+++ b/tests/test_pnum_cycle.c
@@ -1,0 +1,55 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <math.h>
+#include <assert.h>
+#include "../bdssim.h"
+#include "../channel.h"
+#include "../globals.h"
+#include "../bch.h"
+#include "../navbits.h"
+
+static uint32_t read_word(const uint8_t *bits, int idx)
+{
+    uint32_t w = 0;
+    for(int i=0;i<30;i++)
+        w = (w<<1) | bits[idx*30 + i];
+    return w;
+}
+
+int main(void)
+{
+    sim_config_t cfg = {0};
+    snprintf(cfg.rinex_file, sizeof(cfg.rinex_file),
+             "BRDM00DLR_S_20251760000_01D_MN.rnx");
+    if(!init_simulator(&cfg, 0.0)){
+        fprintf(stderr, "init failed\n");
+        return 1;
+    }
+
+    int prn = 8; /* any D1 satellite */
+    uint8_t bits[SUBFRAME_BITS];
+
+    /* check two full cycles of page numbers */
+    for(int frame=0; frame<26; ++frame){
+        int pnum = frame % 24 + 1;
+
+        double t4 = frame*30.0 + 18.0; /* subframe 4 start */
+        get_subframe_bits(prn, 4, nav_week, t4, 6.0, bits);
+        uint32_t w2 = read_word(bits,1);
+        uint32_t sow_int = (uint32_t)(floor(t4/6.0)*6.0);
+        uint32_t payload = ((sow_int & 0xFFF) << 10) | (0 << 9) | ((pnum & 0x7F) << 2) | 0x2;
+        uint32_t expect = bch_interleave_22bit(payload);
+        assert(w2 == expect);
+
+        double t5 = frame*30.0 + 24.0; /* subframe 5 start */
+        get_subframe_bits(prn, 5, nav_week, t5, 6.0, bits);
+        w2 = read_word(bits,1);
+        sow_int = (uint32_t)(floor(t5/6.0)*6.0);
+        payload = ((sow_int & 0xFFF) << 10) | (0 << 9) | ((pnum & 0x7F) << 2) | 0x2;
+        expect = bch_interleave_22bit(payload);
+        assert(w2 == expect);
+    }
+
+    cleanup_simulator();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- cycle PNUM value for subframes 4 and 5
- document the PNUM cycling behaviour
- add regression test for PNUM

## Testing
- `make check`
- `gcc -I. -O2 -Wall -Wextra -fopenmp -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE tests/test_pnum_cycle.c globals.o bch.o navbits.o channel.o rinex.o orbits.o coord.o path.o bdssim.o -o tests/test_pnum_cycle -lm`
- `./tests/test_pnum_cycle`

------
https://chatgpt.com/codex/tasks/task_e_688336ebf0388327ba23a179eb2f0090