### PR TITLE
Ensure path memory freed on error

### DIFF
--- a/bdssim.c
+++ b/bdssim.c
@@ -145,10 +145,18 @@ void generate_signal(const sim_config_t *cfg)
     if(cfg->path_type==1)       load_path_xyz(cfg->path_file,&path);
     else if(cfg->path_type==2)  load_path_llh(cfg->path_file,&path);
     else if(cfg->path_type==3)  load_path_nmea(cfg->path_file,&path);
-    if(cfg->path_type!=0 && path.n==0){fputs("path read error\n",stderr);return;}
+    if(cfg->path_type!=0 && path.n==0){
+        fputs("path read error\n",stderr);
+        free_path(&path);
+        return;
+    }
     if(cfg->path_type==0)      llh2xyz(cfg->llh,&usr);
     else { interpolate_path(&path,0.0,&usr); xyz2llh(usr.xyz,&usr); }
-    if(utc_to_bdt(cfg->time_start,&usr.week,&usr.sow)!=0){fputs("UTC format err\n",stderr);return;}
+    if(utc_to_bdt(cfg->time_start,&usr.week,&usr.sow)!=0){
+        fputs("UTC format err\n",stderr);
+        free_path(&path);
+        return;
+    }
 
     coord_t ref_llh=usr;              /* 保存經緯度作旋轉基準 */
     static_user_at(usr.week,usr.sow,&ref_llh,&usr,NULL);
@@ -179,10 +187,18 @@ void generate_signal(const sim_config_t *cfg)
     FILE *fp=NULL, *fp8=NULL;
     if(cfg->byte_output){
         fp8=fopen("beidou_b1i_u8.bin","wb");
-        if(!fp8){perror("u8"); return;}
+        if(!fp8){
+            perror("u8");
+            free_path(&path);
+            return;
+        }
     } else {
         fp=fopen("beidou_b1i.bin","wb");
-        if(!fp){perror("bin"); return;}
+        if(!fp){
+            perror("bin");
+            free_path(&path);
+            return;
+        }
     }
     int16_t tmpI[MAX_CH][samp_per_ms],tmpQ[MAX_CH][samp_per_ms];
     int32_t accI[samp_per_ms],accQ[samp_per_ms];

--- a/main.c
+++ b/main.c
@@ -187,7 +187,9 @@ int main(int argc,char *argv[])
     else if(cfg.path_type==2)  load_path_llh(cfg.path_file,&path);
     else if(cfg.path_type==3)  load_path_nmea(cfg.path_file,&path);
     if(cfg.path_type!=0 && path.n==0){
-        fputs("路徑檔讀取失敗\n",stderr); return 1;
+        fputs("路徑檔讀取失敗\n",stderr);
+        free_path(&path);
+        return 1;
     }
     if(cfg.path_type==0)      llh2xyz(cfg.llh,&usr);
     else {                    


### PR DESCRIPTION
## Summary
- fix missing `free_path` calls on error paths
- avoid leaks when path or output files cannot be opened

## Testing
- `make`
- `make check`
- `valgrind --leak-check=full ./bds-sim examples/beidou_b1i.conf -o beidou_b1i.bin`

------
https://chatgpt.com/codex/tasks/task_e_68835df4f8288327a78490e6439dc167