### PR TITLE
Remove unused ephemeris fields

### DIFF
--- a/bdssim.h
+++ b/bdssim.h
@@ -22,8 +22,7 @@ typedef struct {
 
     /* 其他 RINEX 欄位（暫未使用） */
     int     aode;            /* Age of Data, Ephemeris (line 2) */
-    int     freq_num;        /* BDS frequency number */
-    double  a0utc, a1utc, a2utc;   /* BDT‑UTC 偏移 */
+    double  a0utc, a1utc;    /* BDT‑UTC 偏移 */
     double  toe_msg;         /* Transmission time of message */
     double  tgd1, tgd2;      /* TGD1/TGD2 group delays */
     int     aodc;            /* Age of Data, Clock */

--- a/rinex.c
+++ b/rinex.c
@@ -120,7 +120,6 @@ int read_rinex_nav(const char *fname, double start_bdt)
         tmp.omegadot= fld(r[3], 3, INDN);
 
         tmp.idot    = fld(r[4], 0, INDN);
-        tmp.freq_num = ifld(r[4], 1, INDN); /* reserved/freq number */
         int week_r = ifld(r[4], 2, INDN);  /* BDS week number */
         tmp.week = week_r;
 


### PR DESCRIPTION
## Summary
- drop `freq_num` and `a2utc` fields
- update RINEX parser accordingly

## Testing
- `make check`
- compiled and ran a small utility to print the BDUT offset

------
https://chatgpt.com/codex/tasks/task_e_688361a1e1448327a46ee438775bcb89