### PR TITLE
Adjust test_orbits time handling

### DIFF
--- a/tests/test_orbits.c
+++ b/tests/test_orbits.c
@@ -1,38 +1,11 @@
 #include <stdio.h>
 #include <stdbool.h>
+#include <string.h>
 #include "../bdssim.h"
 #include "../globals.h"
 #include "../orbits.h"
-#include <time.h>
+#include "../timeconv.h"
 
-/* very small timegm since we cannot rely on the libc one */
-static time_t tiny_timegm(struct tm *t)
-{
-    static const int dim[12] = {31,28,31,30,31,30,31,31,30,31,30,31};
-    int y = t->tm_year + 1900;
-    int m = t->tm_mon;
-    int d = t->tm_mday - 1;             /* 0-based */
-
-    int days = 0;
-    for(int yr=1970; yr<y; ++yr)
-        days += 365 + ((yr%4==0 && yr%100) || (yr%400==0));
-    for(int mo=0; mo<m; ++mo){
-        days += dim[mo];
-        if(mo==1 && ((y%4==0 && y%100) || (y%400==0)))
-            ++days;                     /* Feb 29 */
-    }
-    days += d;
-    return (time_t)days*86400 + t->tm_hour*3600 + t->tm_min*60 + t->tm_sec;
-}
-
-/* convert GPS week/time to BDT week/time (BDT lags GPS by 14 s, epoch 1356w) */
-static void gps_to_bdt(int gps_w, double gps_sow, int *bdt_w, double *bdt_sow)
-{
-    int w = gps_w - 1356;
-    double sow = gps_sow - 14.0;        /* BDT is 14 s behind GPS */
-    if(sow < 0){ sow += 604800.0; --w; }
-    *bdt_w = w; *bdt_sow = sow;
-}
 
 int main(void)
 {
@@ -48,8 +21,8 @@ int main(void)
     if(!fp){ perror("SP3"); return 1; }
 
     char l[256];
-    int gps_w = 0;          /* current GPS week from SP3 */
-    double gps_sow = 0.0;   /* current GPS second-of-week */
+    int bw = 0;             /* current BDT week */
+    double bsow = 0.0;      /* current BDT second-of-week */
 
     int count = 0;          /* number of samples compared */
     double err2_sum = 0.0;  /* squared error accumulator  */
@@ -60,14 +33,14 @@ int main(void)
         if(l[0] == '*'){
             int Y,M,D,h,m; double s;
             sscanf(l+1, "%d %d %d %d %d %lf", &Y,&M,&D,&h,&m,&s);
-            struct tm utc = {0};
-            utc.tm_year=Y-1900; utc.tm_mon=M-1; utc.tm_mday=D;
-            utc.tm_hour=h;     utc.tm_min=m;   utc.tm_sec=(int)s;
-            time_t t = tiny_timegm(&utc);
-            const time_t GPS_EPOCH = 315964800; /* 1980-01-06 */
-            double sec = difftime(t, GPS_EPOCH) + s - (int)s; /* include fractional */
-            gps_w  = (int)(sec / 604800.0);
-            gps_sow= sec - gps_w*604800.0;
+            char utc[32];
+            int is = (int)s;
+            snprintf(utc, sizeof utc, "%04d/%02d/%02d,%02d:%02d:%02d", Y,M,D,h,m,is);
+            if (utc_to_bdt(utc, &bw, &bsow) != 0) {
+                fprintf(stderr, "utc_to_bdt failed\n");
+                return 1;
+            }
+            bsow += s - is; /* add fractional seconds */
             continue;
         }
         if(l[0]=='P' && l[1]=='C'){
@@ -83,8 +56,6 @@ int main(void)
                 printed[prn] = true;
             }
 
-            int bw; double bsow;
-            gps_to_bdt(gps_w, gps_sow, &bw, &bsow);
 
             double xyz[3];
             calc_sat_position_velocity(prn, bw, bsow, xyz, NULL);
@@ -93,10 +64,10 @@ int main(void)
             double dy = xyz[1] - y*1000.0;
             double dz = xyz[2] - z*1000.0;
             double err = sqrt(dx*dx + dy*dy + dz*dz);
-            if(count < 3){
-                printf("%s bw=%d bsow=%.1f PRN%02d err=%.3f\n",
-                       l+1, bw, bsow, prn, err);
-            }
+            char *nl = strchr(l, '\n');
+            if(nl) *nl = '\0';
+            printf("%s bw=%d bsow=%.3f PRN%02d calc=(%.3f %.3f %.3f) err=%.3f\n",
+                   l, bw, bsow, prn, xyz[0], xyz[1], xyz[2], err);
             err2_sum += err*err;
             ++count;
         }


### PR DESCRIPTION
## Summary
- use `utc_to_bdt` from timeconv for epoch conversion
- print calculated position for each satellite

## Testing
- `make tests/test_orbits`
- `./tests/test_orbits | tail -n 5`
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_688398e9e6a08327bfefcc70a2614ccd