### PR TITLE
Remove BDUT ephemeris handling and update BDT offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Adjust the `ChannelX.satellite` lines accordingly or set
 searches for the correct PRNs automatically.
 
 ## v0.3.0 (2025-07-07)
-* Fix UTC→BDT +14 s
+* Fix UTC→BDT +4 s
 * GEO satellites enabled
 * Added subframe 4/5 template
 * Default Fs → 5.120 MHz

--- a/globals.c
+++ b/globals.c
@@ -18,7 +18,7 @@ double nav_time_max = 0.0;
 int    nav_week     = 0;
 double iono_alpha[4] = {0};
 double iono_beta[4]  = {0};
-int    utc_bdt_diff  = 14;  /* default UTC->BDT offset */
+int    utc_bdt_diff  = 4;   /* default UTC->BDT offset */
 
 int simulator_inited = 0;
 

--- a/rinex.c
+++ b/rinex.c
@@ -53,12 +53,6 @@ int read_rinex_nav(const char *fname, double start_bdt)
                    &iono_beta[2], &iono_beta[3]);
             continue;
         }
-        if(strncmp(l,"BDUT",4)==0){
-            double a0,a1; int off;
-            if(sscanf(l+4, "%lf %lf %d", &a0, &a1, &off)==3)
-                utc_bdt_diff = off;
-            continue;
-        }
         if (strstr(l, "END OF HEADER")) break;
     }
 

--- a/tests/test_orbits.c
+++ b/tests/test_orbits.c
@@ -35,7 +35,7 @@ int main(void)
                 return 1;
             }
             bsow += s - is; /* fractional seconds */
-            bsow -= 28.0;    /* manual -14 s */
+            bsow -= 8.0;     /* manual -4 s */
             if(bsow < 0){ bsow += 604800.0; --bw; }
             if(!got_epoch){
                 double start_bdt = bw*604800.0 + bsow;

--- a/tests/test_timeconv.c
+++ b/tests/test_timeconv.c
@@ -2,7 +2,7 @@
 #include <time.h>
 #include "timeconv.h"
 
-int utc_bdt_diff = 14;
+int utc_bdt_diff = 4;
 
 int main(int argc, char *argv[])
 {


### PR DESCRIPTION
## Summary
- drop BDUT time system parsing from RINEX reader
- default UTC→BDT offset is now 4 s
- adjust unit tests and docs for the new offset

## Testing
- `make check`
- `make tests/test_timeconv`
- `./tests/test_timeconv 2025/06/25,00:00:00`

------
https://chatgpt.com/codex/tasks/task_e_6883bf36c88483279b4bc108b1f90fef