### PR TITLE
Refine satellite orbit classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,4 +12,6 @@
 * Amplitude API no longer depends on channel count
 * Allow --start up to 24 h past last ephemeris
 * Improved utc_to_bdt() handling of negative offsets
+* Orbit classification now distinguishes IGSO and MEO by
+  checking the ephemeris `sqrtA` value
 

--- a/README.md
+++ b/README.md
@@ -69,8 +69,11 @@ The legacy option `-byte` is still recognised as an alias for `--byte`.
 ## 訊號型別
 
 - GEO PRN → D2 (500 bps, 無 NH 二次碼)
-- MEO/IGSO PRN → D1 (50 bps, 有 NH 二次碼)
+- IGSO/MEO PRN → D1 (50 bps, 有 NH 二次碼)
 - `--force-d2` 可把所有 PRN 強制成 D2
+
+MEO 與 IGSO 依據星曆中的 `sqrtA`(軌道半長軸平方根) 分辨。大於 6000 的視
+為與 GEO 相同的軌道高度，即 IGSO，否則為 MEO。
 
 ## Usage
 
@@ -96,7 +99,9 @@ the level but may cause clipping.
 
 The amplitude itself is derived from a simple link budget.  Each orbit
 type is assigned a nominal transmit power (about 52 dBm for GEO,
-53 dBm for IGSO and 55 dBm for MEO).  Path loss is computed from the
+53 dBm for IGSO and 55 dBm for MEO).  Orbit type is detected by
+checking `sqrtA` so that IGSO and MEO receive the proper power.
+Path loss is computed from the
 current slant range including a fixed 2 dB atmospheric term.  The gain
 factor multiplies this result before limiting to the 16‑bit output
 range.  The computed power is further adjusted toward the target

--- a/channel.c
+++ b/channel.c
@@ -43,6 +43,33 @@ static inline void fast_sincos(double ph,float*co,float*si){
 
 static const int geo_prn[] = {1,2,3,4,5,59,60,61,62,63};
 
+static int is_geo_prn(int prn); /* forward */
+
+/* classify IGSO/MEO via sqrtA (semi-major axis).  BDS IGSO shares
+ * the GEO semi-major axis (~42164 km, sqrtA around 6493), whereas
+ * MEO satellites use a smaller semi-major axis (~27800 km, sqrtA
+ * around 5282).  This allows for more robust identification even if
+ * PRN assignments change. */
+int is_igso_prn(int prn)
+{
+    if(is_geo_prn(prn))
+        return 0;
+    if(prn<1 || prn>=MAX_SAT) return 0;
+    const ephemeris_t *ep=&eph[prn];
+    if(ep->prn==0) return 0;
+    return ep->sqrtA > 6000.0;  /* ~42164 km orbit */
+}
+
+int is_meo_prn(int prn)
+{
+    if(is_geo_prn(prn))
+        return 0;
+    if(prn<1 || prn>=MAX_SAT) return 0;
+    const ephemeris_t *ep=&eph[prn];
+    if(ep->prn==0) return 0;
+    return ep->sqrtA <= 6000.0; /* ~27800 km orbit */
+}
+
 static int is_geo_prn(int prn)
 {
     for(size_t i=0;i<sizeof(geo_prn)/sizeof(geo_prn[0]);++i)
@@ -57,9 +84,9 @@ int is_d2_prn(int prn)
 
 static double sat_eirp_dbm(int prn)
 {
-    if(is_geo_prn(prn))      return 52.0; /* GEO */
-    else if(prn>=6 && prn<=10) return 53.0; /* IGSO (粗略) */
-    else                      return 55.0; /* MEO  */
+    if(is_geo_prn(prn))     return 52.0; /* GEO */
+    else if(is_igso_prn(prn)) return 53.0; /* IGSO */
+    else                    return 55.0; /* MEO */
 }
 
 /* 大氣衰減常數 (dB) */

--- a/channel.h
+++ b/channel.h
@@ -35,6 +35,8 @@ void gen_samples_1ms(channel_t *, int week, double sow,
 void gen_samples_1ms_d2(channel_t *, int week, double sow,
                         int samp_per_ms, int16_t *I, int16_t *Q);
 int  is_d2_prn(int prn);
+int  is_igso_prn(int prn);
+int  is_meo_prn(int prn);
 
 /* === 修正：用指標而非 array declarator === */
 void get_subframe_bits(int prn, int sf_id, int week, double sow,


### PR DESCRIPTION
## Summary
- classify IGSO vs MEO using `sqrtA`
- expose `is_igso_prn`/`is_meo_prn` helpers
- update amplitude model to use refined classification
- document orbit detection in README
- note update in CHANGELOG

## Testing
- `make clean`
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_6883cba6b8f08327a3961c4c157ef14e