### PR TITLE
Prioritise GEO satellites when --force-d2 is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ The legacy option `-byte` is still recognised as an alias for `--byte`.
 - GEO PRN → D2 (500 bps, 無 NH 二次碼)
 - IGSO/MEO PRN → D1 (50 bps, 有 NH 二次碼)
 - `--force-d2` 可把所有 PRN 強制成 D2
+  此模式會在挑選模擬衛星時優先加入可見的 GEO 衛星
 
 MEO 與 IGSO 依據星曆中的 `sqrtA`(軌道半長軸平方根) 分辨。大於 6000 的視
 為與 GEO 相同的軌道高度，即 IGSO，否則為 MEO。

--- a/bdssim.c
+++ b/bdssim.c
@@ -78,9 +78,11 @@ static void static_user_at(int week,double sow,const coord_t*ref,
 }
 
 /*----------------------------------------------------*/
-int select_channels(channel_t *ch,int *n,const coord_t*u)
+int select_channels(channel_t *ch,int *n,const coord_t*u,
+                    bool force_d2)
 {
-    struct cand{int prn;double elev,rho,rdot;} c[63]; int m=0;
+    struct cand{int prn;double elev,rho,rdot;int pri;} c[63];
+    int m=0;
     double uv[3]={-OMEGA_E*u->xyz[1], OMEGA_E*u->xyz[0], 0.0};
     for(int prn=1;prn<=63;++prn){
         double sat[3],vel[3];
@@ -90,11 +92,16 @@ int select_channels(channel_t *ch,int *n,const coord_t*u)
         double dx=sat[0]-u->xyz[0], dy=sat[1]-u->xyz[1], dz=sat[2]-u->xyz[2];
         double rho=hypot(hypot(dx,dy),dz);
         double rdot=(dx*(vel[0]-uv[0]) + dy*(vel[1]-uv[1]) + dz*(vel[2]-uv[2]))/rho;
-        c[m++] = (struct cand){prn,el,rho,rdot};
+        int pri = (force_d2 && is_d2_prn(prn)) ? 1 : 0;
+        c[m++] = (struct cand){prn,el,rho,rdot,pri};
     }
-    /* sort by elevation (desc) */
-    for(int i=0;i<m-1;++i) for(int j=i+1;j<m;++j)
-        if(c[j].elev>c[i].elev){struct cand t=c[i];c[i]=c[j];c[j]=t;}
+    /* sort by priority and elevation (desc) */
+    for(int i=0;i<m-1;++i) for(int j=i+1;j<m;++j){
+        if(c[j].pri>c[i].pri ||
+           (c[j].pri==c[i].pri && c[j].elev>c[i].elev)){
+            struct cand t=c[i];c[i]=c[j];c[j]=t;
+        }
+    }
     *n = m<MAX_CH?m:MAX_CH;
     for(int i=0;i<*n;++i) channel_reset(&ch[i],c[i].prn,u->week,u->sow);
     return *n;
@@ -102,9 +109,10 @@ int select_channels(channel_t *ch,int *n,const coord_t*u)
 
 /* 更新當前可見通道（可動態加入/移除） */
 static void update_channels_dynamic(channel_t *ch,int *n,const coord_t *u,
-                                    const double uvel[3],double gain,double target_cn0)
+                                    const double uvel[3],double gain,double target_cn0,
+                                    bool force_d2)
 {
-    struct cand{int prn;double elev,rho,rdot;} cand[63];
+    struct cand{int prn;double elev,rho,rdot;int pri;} cand[63];
     int m=0;
     double uv[3];
     if(uvel) { uv[0]=uvel[0]; uv[1]=uvel[1]; uv[2]=uvel[2]; }
@@ -117,10 +125,15 @@ static void update_channels_dynamic(channel_t *ch,int *n,const coord_t *u,
         double dx=sat[0]-u->xyz[0], dy=sat[1]-u->xyz[1], dz=sat[2]-u->xyz[2];
         double rho=hypot(hypot(dx,dy),dz);
         double rdot=(dx*(vel[0]-uv[0]) + dy*(vel[1]-uv[1]) + dz*(vel[2]-uv[2]))/rho;
-        cand[m++] = (struct cand){prn,el,rho,rdot};
+        int pri = (force_d2 && is_d2_prn(prn)) ? 1 : 0;
+        cand[m++] = (struct cand){prn,el,rho,rdot,pri};
     }
-    for(int i=0;i<m-1;++i) for(int j=i+1;j<m;++j)
-        if(cand[j].elev>cand[i].elev){struct cand t=cand[i];cand[i]=cand[j];cand[j]=t;}
+    for(int i=0;i<m-1;++i) for(int j=i+1;j<m;++j){
+        if(cand[j].pri>cand[i].pri ||
+           (cand[j].pri==cand[i].pri && cand[j].elev>cand[i].elev)){
+            struct cand t=cand[i];cand[i]=cand[j];cand[j]=t;
+        }
+    }
 
     int new_n = m<MAX_CH?m:MAX_CH;
     channel_t new_ch[MAX_CH];
@@ -166,7 +179,9 @@ void generate_signal(const sim_config_t *cfg)
     /* 檢查 start 時間是否與星曆 toe 接近 */
     check_ephemeris_age(usr.week, usr.sow);
 
-    channel_t ch[MAX_CH]; int n_ch; select_channels(ch,&n_ch,&usr);
+    channel_t ch[MAX_CH];
+    int n_ch;
+    select_channels(ch,&n_ch,&usr,cfg->force_d2);
 
     double fs = cfg->byte_output ? FSAMP_BYTE : FSAMP_DEF;
     int samp_per_ms = (int)(fs/1000.0 + 0.5);
@@ -228,7 +243,8 @@ void generate_signal(const sim_config_t *cfg)
             uvel[2]=(usr.xyz[2]-prev.xyz[2])/dt;
         }
 
-        update_channels_dynamic(ch,&n_ch,&usr,uvel,cfg->gain,cfg->target_cn0);
+        update_channels_dynamic(ch,&n_ch,&usr,uvel,cfg->gain,
+                                cfg->target_cn0,cfg->force_d2);
 
         /* --- STEP_MS 次 1ms 取樣 --- */
         for(int step=0;step<STEP_MS;++step){

--- a/bdssim.h
+++ b/bdssim.h
@@ -63,5 +63,6 @@ bool  init_simulator(sim_config_t *, double start_bdt);
 void  generate_signal(const sim_config_t *cfg);   /* ← 加上 const */
 void  cleanup_simulator(void);
 /* 讓 main 可以先做一次 select_channels() 取得 PRN 清單 */
-int  select_channels(channel_t *ch, int *n_ch, const coord_t *usr);
+int  select_channels(channel_t *ch, int *n_ch, const coord_t *usr,
+                     bool force_d2);
 #endif

--- a/main.c
+++ b/main.c
@@ -201,7 +201,7 @@ int main(int argc,char *argv[])
 
     channel_t ch[MAX_CH];
     int n_ch;
-    select_channels(ch,&n_ch,&usr);
+    select_channels(ch,&n_ch,&usr,cfg.force_d2);
 
     /* 印出確認訊息 (簡潔模式) */
     printf("[cfg] UTC %s  BDT W%d %.3f\n",


### PR DESCRIPTION
## Summary
- prioritise visible GEO satellites when `--force-d2` is enabled
- adjust channel selection logic accordingly
- document the new behaviour in README

## Testing
- `make -j$(nproc)`
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_6888a30fd8dc83279a451a199d0e62ee