### PR TITLE
Fix dynamic Doppler calculation

### DIFF
--- a/bdssim.c
+++ b/bdssim.c
@@ -234,13 +234,19 @@ void generate_signal(const sim_config_t *cfg)
         if(cfg->path_type==0){
             static_user_at(week,sow,&ref_usr,&usr,uvel);
         } else {
-            coord_t prev=usr;
-            interpolate_path(&path, ms/1000.0, &usr);
-            xyz2llh(usr.xyz,&usr);
+            double prev_eci[3]={usr.xyz[0], usr.xyz[1], usr.xyz[2]};
+            coord_t ecef;
+            interpolate_path(&path, ms/1000.0, &ecef);
+            xyz2llh(ecef.xyz,&ecef);
+            ecef_to_eci(week, sow, ecef.xyz, usr.xyz);
+            usr.llh[0]=ecef.llh[0];
+            usr.llh[1]=ecef.llh[1];
+            usr.llh[2]=ecef.llh[2];
+            usr.week=week; usr.sow=sow;
             double dt=STEP_MS*0.001;
-            uvel[0]=(usr.xyz[0]-prev.xyz[0])/dt;
-            uvel[1]=(usr.xyz[1]-prev.xyz[1])/dt;
-            uvel[2]=(usr.xyz[2]-prev.xyz[2])/dt;
+            uvel[0]=(usr.xyz[0]-prev_eci[0])/dt;
+            uvel[1]=(usr.xyz[1]-prev_eci[1])/dt;
+            uvel[2]=(usr.xyz[2]-prev_eci[2])/dt;
         }
 
         update_channels_dynamic(ch,&n_ch,&usr,uvel,cfg->gain,

--- a/coord.c
+++ b/coord.c
@@ -1,4 +1,7 @@
 #include "coord.h"
+#include "globals.h"  /* nav_week */
+
+#define OMEGA_E 7.2921150e-5
 
 /* LLH → ECEF，並把 llh/xyz 一併寫回 coord_t -------------- */
 void llh2xyz(const double llh_deg[3], coord_t *c)
@@ -66,5 +69,16 @@ double enu_elevation_deg(const double enu[3])
     const double rho = sqrt(enu[0]*enu[0] + enu[1]*enu[1] + enu[2]*enu[2]);
     if (rho == 0.0) return -90.0;   /* 防除以零 */
     return asin( enu[2] / rho ) * 180.0 / M_PI;
+}
+
+/* ECEF -> ECI ------------------------------------------------------- */
+void ecef_to_eci(int week, double sow, const double ecef[3], double eci[3])
+{
+    double t = (week - nav_week) * 604800.0 + sow;
+    double theta = OMEGA_E * t;
+    double cosT = cos(theta), sinT = sin(theta);
+    eci[0] = cosT * ecef[0] - sinT * ecef[1];
+    eci[1] = sinT * ecef[0] + cosT * ecef[1];
+    eci[2] = ecef[2];
 }
 

--- a/coord.h
+++ b/coord.h
@@ -19,6 +19,7 @@ void   llh2xyz(const double llh_deg[3], coord_t *c);
 void   xyz2llh(const double xyz[3], coord_t *c);
 void   ecef2enu(const coord_t *usr, const double sat_xyz[3], double enu[3]);
 double enu_elevation_deg(const double enu[3]);
+void   ecef_to_eci(int week, double sow, const double ecef[3], double eci[3]);
 
 #endif
 


### PR DESCRIPTION
## Summary
- add `ecef_to_eci` coordinate conversion helper
- use `ecef_to_eci` when updating user path so satellite geometry stays in the same frame

## Testing
- `make`
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_6889aaf52db483279a653b9c28e34767