### PR TITLE
Add antenna gain and multipath modeling

### DIFF
--- a/bdssim.c
+++ b/bdssim.c
@@ -143,7 +143,7 @@ static void update_channels_dynamic(channel_t *ch,int *n,const coord_t *u,
         if(idx>=0) new_ch[i]=ch[idx];
         else       channel_reset(&new_ch[i],cand[i].prn,u->week,u->sow);
         update_channel_dynamics(&new_ch[i],cand[i].rho,cand[i].rdot,
-                                gain,target_cn0);
+                                cand[i].elev,gain,target_cn0);
     }
     for(int i=0;i<new_n;++i) ch[i]=new_ch[i];
     *n = new_n;
@@ -192,10 +192,12 @@ void generate_signal(const sim_config_t *cfg)
     for(int i=0;i<n_ch;++i){
         double sat[3],vel[3];
         calc_sat_position_velocity(ch[i].prn,usr.week,usr.sow,sat,vel);
+        double enu[3]; ecef2enu(&usr,sat,enu);
+        double el=enu_elevation_deg(enu);
         double dx=sat[0]-usr.xyz[0],dy=sat[1]-usr.xyz[1],dz=sat[2]-usr.xyz[2];
         double rho=hypot(hypot(dx,dy),dz);
         double rdot=(dx*(vel[0]-uvel[0]) + dy*(vel[1]-uvel[1]) + dz*(vel[2]-uvel[2]))/rho;
-        update_channel_dynamics(&ch[i],rho,rdot,cfg->gain,cfg->target_cn0);
+        update_channel_dynamics(&ch[i],rho,rdot,el,cfg->gain,cfg->target_cn0);
         printf("[ch%02d] rdot %.2f fd %.2fHz\n", ch[i].prn, rdot, ch[i].fd);
     }
 

--- a/channel.c
+++ b/channel.c
@@ -12,6 +12,31 @@
 static double fs = 5.120e6;           /* default sample rate */
 #define DBM_REF   (-130.0)         /* ±1.0 → –130 dBm */
 
+/* ---- Receiver antenna pattern (0° boresight) ---- */
+static const double ant_pat_db[37]={
+    0.00,  0.00,  0.22,  0.44,  0.67,  1.11,  1.56,  2.00,  2.44,  2.89,
+    3.56,  4.22,  4.89,  5.56,  6.22,  6.89,  7.56,  8.22,  8.89,  9.78,
+   10.67, 11.56, 12.44, 13.33, 14.44, 15.56, 16.67, 17.78, 18.89, 20.00,
+   21.33, 22.67, 24.00, 25.56, 27.33, 29.33, 31.56
+};
+static double ant_pat[37];
+__attribute__((constructor)) static void init_ant_gain(void){
+    for(int i=0;i<37;i++) ant_pat[i]=pow(10.0,-ant_pat_db[i]/20.0);
+}
+
+static double antenna_gain(double elev_deg)
+{
+    int idx=(int)((90.0-elev_deg)/5.0);
+    if(idx<0) idx=0; else if(idx>36) idx=36;
+    return ant_pat[idx];
+}
+
+/* simple multipath loss model: -3 dB below 15° elevation */
+static double multipath_loss(double elev_deg)
+{
+    return (elev_deg<15.0)? pow(10.0,-3.0/20.0) : 1.0;
+}
+
 /* ---------- 32k sin LUT ---------- */
 #define LUTBITS   15
 #define LUTSIZE   (1u<<LUTBITS)
@@ -160,8 +185,13 @@ void channel_reset(channel_t *c,int prn,int week,double sow){
     channel_set_time(c,week,sow);
 }
 /* 幾何→計算振幅 / 初始多普勒 */
-void update_channel_dynamics(channel_t *c,double rho,double rdot,double gain,double target_cn0){
-    c->amp = calc_amp(c->prn,rho,gain,target_cn0);
+void update_channel_dynamics(channel_t *c,double rho,double rdot,double elev_deg,
+                             double gain,double target_cn0){
+    double a = calc_amp(c->prn,rho,gain,target_cn0);
+    double ant = antenna_gain(elev_deg);
+    double mp  = multipath_loss(elev_deg);
+    c->amp = a * ant * mp;
+    c->elev_deg = elev_deg;
     c->fd  = -FCARRIER*rdot/299792458.0;               /* Doppler (Hz) */
     /*
      * Positive range rate (rdot) means the satellite is moving away

--- a/channel.h
+++ b/channel.h
@@ -13,6 +13,7 @@ typedef struct {
     double  code_rate;    /* chipping rate             */
     double  carr_phase;   /* rad                       */
     double  code_phase;   /* chips                     */
+    double  elev_deg;     /* satellite elevation (deg) */
     uint16_t code_ptr;
     uint16_t bit_ptr;
     uint8_t  sf_id;
@@ -28,7 +29,7 @@ typedef struct {
 void channel_reset(channel_t *, int prn, int week, double sow);
 void channel_set_time(channel_t *, int week, double sow);
 void update_channel_dynamics(channel_t *, double rho, double rdot,
-                             double gain, double target_cn0);
+                             double elev_deg, double gain, double target_cn0);
 void channel_set_fs(double sample_rate);
 void gen_samples_1ms(channel_t *, int week, double sow,
                      int samp_per_ms, int16_t *I, int16_t *Q);

--- a/tests/test_d2_cycles.c
+++ b/tests/test_d2_cycles.c
@@ -21,7 +21,7 @@ int main(void)
     channel_reset(&ch, prn, nav_week, 0.0);
     ch.carr_phase = 0.0;
     ch.code_phase = 0.1; /* avoid boundary ambiguity */
-    update_channel_dynamics(&ch, 2.0e7, 0.0, 1.0, cfg.target_cn0);
+    update_channel_dynamics(&ch, 2.0e7, 0.0, 90.0, 1.0, cfg.target_cn0);
     channel_set_fs(5.12e6);
 
     int samp_per_ms = (int)(5.12e6/1000.0 + 0.5);

--- a/tests/test_nh_prn.c
+++ b/tests/test_nh_prn.c
@@ -21,7 +21,7 @@ int main(void)
     channel_reset(&ch, prn, nav_week, 0.0);
     ch.carr_phase = 0.0;
     ch.code_phase = 0.1; /* avoid boundary ambiguity */
-    update_channel_dynamics(&ch, 2.0e7, 0.0, 1.0, cfg.target_cn0);
+    update_channel_dynamics(&ch, 2.0e7, 0.0, 90.0, 1.0, cfg.target_cn0);
     channel_set_fs(5.12e6);
 
     int samp_per_ms = (int)(5.12e6/1000.0 + 0.5);


### PR DESCRIPTION
## Summary
- add receiver antenna gain pattern and simple multipath loss
- expose elevation in `channel_t` and update dynamic updates
- adapt tests to new API

## Testing
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_6889c95a66f08327810c2e33d4623dab