### PR TITLE
Fix BDSSIM output scaling and independent 8‑bit generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,10 @@ default the file is written at **5.120 MHz**.  Each sample is a pair of
 careful not to interpret the file as 8‑bit data—otherwise the Q channel
 may appear to contain only zeros or `-1` values.
 Using the `--byte` flag writes `beidou_b1i_u8.bin` containing the **8‑bit**
-I channel only, sampled at **25 MHz** for use with GNSS‑SDR.  The Q samples are
-discarded entirely.
+I channel only, sampled at **25 MHz** for use with GNSS‑SDR.  The samples are
+generated directly from the internal accumulator rather than converting the
+16‑bit stream.  All output values are normalised to remain within ±1 before
+quantisation so the integers never exceed the format limits.
 The legacy option `-byte` is still recognised as an alias for `--byte`.
 
 ## 訊號型別

--- a/bdssim.c
+++ b/bdssim.c
@@ -292,6 +292,7 @@ void generate_signal(const sim_config_t *cfg)
             /* 限幅並打包成 I/Q (加入 AWGN) */
             int16_t iq[2*samp_per_ms];
             int8_t  i8[samp_per_ms];            /* byte output holds I only */
+            double  scale = 1.0/32768.0;
             for(int k=0;k<samp_per_ms;++k){
                 int32_t i=accI[k];
                 int32_t q=accQ[k];
@@ -299,15 +300,22 @@ void generate_signal(const sim_config_t *cfg)
                     i += lrint(cfg->noise_std*gauss_rand());
                     q += lrint(cfg->noise_std*gauss_rand());
                 }
-                if(i>32767)i=32767; else if(i<-32768)i=-32768;
-                if(q>32767)q=32767; else if(q<-32768)q=-32768;
-                iq[2*k]   = (int16_t)i;
-                iq[2*k+1] = (int16_t)q;
-                i8[k]     = (int8_t)(iq[2*k]/256);
-                sumI  += iq[2*k];
-                sumQ  += iq[2*k+1];
-                sumI2 += (double)iq[2*k]*iq[2*k];
-                sumQ2 += (double)iq[2*k+1]*iq[2*k+1];
+                double fi = i*scale;
+                double fq = q*scale;
+                if(fi>1.0)fi=1.0; else if(fi<-1.0)fi=-1.0;
+                if(fq>1.0)fq=1.0; else if(fq<-1.0)fq=-1.0;
+                if(fp){
+                    iq[2*k]   = (int16_t)lrint(fi*32767.0);
+                    iq[2*k+1] = (int16_t)lrint(fq*32767.0);
+                    sumI  += iq[2*k];
+                    sumQ  += iq[2*k+1];
+                    sumI2 += (double)iq[2*k]*iq[2*k];
+                    sumQ2 += (double)iq[2*k+1]*iq[2*k+1];
+                } else {
+                    i8[k] = (int8_t)lrint(fi*127.0);
+                    sumI  += i8[k];
+                    sumI2 += (double)i8[k]*i8[k];
+                }
             }
             samp_cnt += samp_per_ms;
             if(fp)


### PR DESCRIPTION
## Summary
- normalize composite samples to ±1 before quantisation
- write 8‑bit stream directly instead of converting from 16‑bit
- document byte-output changes and scaling behaviour

## Testing
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_6889ccb7dd388327b408a1afa0363f93