### PR TITLE
Add PRN filtering and non-GEO option

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ The legacy option `-byte` is still recognised as an alias for `--byte`.
 - GEO PRN → D2 (500 bps, 無 NH 二次碼)
 - IGSO/MEO PRN → D1 (50 bps, 有 NH 二次碼)
 - `--geo-first` 在挑選模擬衛星時會優先加入可見的 GEO 衛星
+- `--no-geo` 排除所有 GEO 衛星
+- `--prn`  可只輸出指定 PRN
 
 MEO 與 IGSO 依據星曆中的 `sqrtA`(軌道半長軸平方根) 分辨。大於 6000 的視
 為與 GEO 相同的軌道高度，即 IGSO，否則為 MEO。
@@ -93,6 +95,20 @@ Example prioritising visible GEO satellites:
 ```
 ./bds-sim --rinex BRDM00DLR_S_20251870000_01D_MN.rnx \
           --geo-first --duration 120
+```
+
+Example excluding GEO satellites:
+
+```
+./bds-sim --rinex BRDM00DLR_S_20251760000_01D_MN.rnx \
+          --no-geo --duration 60
+```
+
+Example generating only PRN 6:
+
+```
+./bds-sim --rinex BRDM00DLR_S_20251760000_01D_MN.rnx \
+          --prn 6 --duration 60
 ```
 
 `--gain` scales the output amplitude.  With the default gain of `1.0`

--- a/bdssim.c
+++ b/bdssim.c
@@ -79,12 +79,14 @@ static void static_user_at(int week,double sow,const coord_t*ref,
 
 /*----------------------------------------------------*/
 int select_channels(channel_t *ch,int *n,const coord_t*u,
-                    bool geo_first)
+                    bool geo_first,int single_prn,bool no_geo)
 {
     struct cand{int prn;double elev,rho,rdot;int pri;} c[63];
     int m=0;
     double uv[3]={-OMEGA_E*u->xyz[1], OMEGA_E*u->xyz[0], 0.0};
     for(int prn=1;prn<=63;++prn){
+        if(single_prn>0 && prn!=single_prn) continue;
+        if(no_geo && is_d2_prn(prn)) continue;
         double sat[3],vel[3];
         calc_sat_position_velocity(prn,u->week,u->sow,sat,vel);
         double enu[3]; ecef2enu(u,sat,enu);
@@ -110,7 +112,7 @@ int select_channels(channel_t *ch,int *n,const coord_t*u,
 /* 更新當前可見通道（可動態加入/移除） */
 static void update_channels_dynamic(channel_t *ch,int *n,const coord_t *u,
                                     const double uvel[3],double gain,double target_cn0,
-                                    bool geo_first)
+                                    bool geo_first,int single_prn,bool no_geo)
 {
     struct cand{int prn;double elev,rho,rdot;int pri;} cand[63];
     int m=0;
@@ -118,6 +120,8 @@ static void update_channels_dynamic(channel_t *ch,int *n,const coord_t *u,
     if(uvel) { uv[0]=uvel[0]; uv[1]=uvel[1]; uv[2]=uvel[2]; }
     else { uv[0]=uv[1]=uv[2]=0.0; }
     for(int prn=1;prn<=63;++prn){
+        if(single_prn>0 && prn!=single_prn) continue;
+        if(no_geo && is_d2_prn(prn)) continue;
         double sat[3],vel[3];
         calc_sat_position_velocity(prn,u->week,u->sow,sat,vel);
         double enu[3]; ecef2enu(u,sat,enu);
@@ -181,7 +185,8 @@ void generate_signal(const sim_config_t *cfg)
 
     channel_t ch[MAX_CH];
     int n_ch;
-    select_channels(ch,&n_ch,&usr,cfg->geo_first);
+    select_channels(ch,&n_ch,&usr,cfg->geo_first,
+                    cfg->single_prn,cfg->no_geo);
 
     double fs = cfg->byte_output ? FSAMP_BYTE : FSAMP_DEF;
     int samp_per_ms = (int)(fs/1000.0 + 0.5);
@@ -264,7 +269,8 @@ void generate_signal(const sim_config_t *cfg)
         }
 
         update_channels_dynamic(ch,&n_ch,&usr,uvel,cfg->gain,
-                                cfg->target_cn0,cfg->geo_first);
+                                cfg->target_cn0,cfg->geo_first,
+                                cfg->single_prn,cfg->no_geo);
 
         /* --- STEP_MS 次 1ms 取樣 --- */
         for(int step=0;step<STEP_MS;++step){

--- a/bdssim.h
+++ b/bdssim.h
@@ -56,6 +56,8 @@ typedef struct {
     unsigned noise_seed;       /* AWGN 亂數種子 */
     bool     byte_output;      /* 以 8-bit 檔輸出 */
     bool     geo_first;        /* 優先可見 GEO 衛星 */
+    bool     no_geo;           /* 排除 GEO 衛星 */
+    int      single_prn;       /* 僅模擬此 PRN (0 = 全部) */
 } sim_config_t;
 
 /* ---------- 介面 ---------- */
@@ -64,5 +66,5 @@ void  generate_signal(const sim_config_t *cfg);   /* ← 加上 const */
 void  cleanup_simulator(void);
 /* 讓 main 可以先做一次 select_channels() 取得 PRN 清單 */
 int  select_channels(channel_t *ch, int *n_ch, const coord_t *usr,
-                     bool geo_first);
+                     bool geo_first, int single_prn, bool no_geo);
 #endif

--- a/main.c
+++ b/main.c
@@ -24,6 +24,8 @@ static void usage(const char *p)
     puts("  --seed n            雜訊亂數種子 (整數)");
     puts("  --byte               輸出 I-only 之 8-bit 檔");
     puts("  --geo-first          優先可見 GEO 衛星");
+    puts("  --no-geo            排除 GEO 衛星");
+    puts("  --prn N             僅模擬指定 PRN");
     puts("  --help               顯示本說明\n");
 }
 
@@ -39,6 +41,8 @@ int main(int argc,char *argv[])
     cfg.noise_seed  = 1;
     cfg.byte_output = false;
     cfg.geo_first  = false;
+    cfg.no_geo     = false;
+    cfg.single_prn = 0;
     bool llh_given   = false;
 
     /* 處理 "-byte" 舊習慣 */
@@ -61,12 +65,14 @@ int main(int argc,char *argv[])
         {"seed",     required_argument, 0, 'R'},
         {"byte",     no_argument,       0, 'b'},
         {"geo-first",no_argument,       0, 'G'},
+        {"no-geo",   no_argument,       0, 'O'},
+        {"prn",      required_argument, 0, 'p'},
         {"help",     no_argument,       0, 'h'},
         {0,0,0,0}
     };
 
     int c, idx;
-    while((c = getopt_long(argc, argv, "e:t:l:x:y:n:d:g:z:R:hbG", longopt, &idx)) != -1){
+    while((c = getopt_long(argc, argv, "e:t:l:x:y:n:d:g:z:R:hbGOp:", longopt, &idx)) != -1){
         switch(c){
         case 'e':
             strncpy(cfg.rinex_file, optarg, sizeof(cfg.rinex_file)-1);
@@ -124,6 +130,12 @@ int main(int argc,char *argv[])
         case 'G':
             cfg.geo_first = true;
             break;
+        case 'O':
+            cfg.no_geo = true;
+            break;
+        case 'p':
+            cfg.single_prn = atoi(optarg);
+            break;
         case 'h':
             usage(argv[0]);
             return 0;
@@ -155,6 +167,10 @@ int main(int argc,char *argv[])
        cfg.llh[1]<-180.0 || cfg.llh[1]>180.0 ||
        cfg.llh[2]<-1000.0 || cfg.llh[2]>20000.0){
         fputs("--llh 超出合理範圍\n", stderr);
+        return 1;
+    }
+    if(cfg.single_prn<0 || cfg.single_prn>63){
+        fputs("--prn 範圍 1-63\n", stderr);
         return 1;
     }
 
@@ -201,7 +217,7 @@ int main(int argc,char *argv[])
 
     channel_t ch[MAX_CH];
     int n_ch;
-    select_channels(ch,&n_ch,&usr,cfg.geo_first);
+    select_channels(ch,&n_ch,&usr,cfg.geo_first,cfg.single_prn,cfg.no_geo);
 
     /* 印出確認訊息 (簡潔模式) */
     printf("[cfg] UTC %s  BDT W%d %.3f\n",


### PR DESCRIPTION
## Summary
- allow filtering to a single PRN and excluding GEO satellites
- update channel selection routines
- document new `--no-geo` and `--prn` options

## Testing
- `make clean`
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_6889f9b8f5e88327b01e74dac78a97af