### PR TITLE
Add global CN0 control and clipping

### DIFF
--- a/bdssim.c
+++ b/bdssim.c
@@ -114,6 +114,7 @@ static void update_channels_dynamic(channel_t *ch,int *n,const coord_t *u,
                                     const double uvel[3],double gain,double target_cn0,
                                     bool geo_first,int single_prn,bool no_geo)
 {
+    (void)target_cn0; /* now using global g_target_cn0 */
     struct cand{int prn;double elev,rho,rdot;int pri;} cand[63];
     int m=0;
     double uv[3];
@@ -147,7 +148,7 @@ static void update_channels_dynamic(channel_t *ch,int *n,const coord_t *u,
         if(idx>=0) new_ch[i]=ch[idx];
         else       channel_reset(&new_ch[i],cand[i].prn,u->week,u->sow);
         update_channel_dynamics(&new_ch[i],cand[i].rho,cand[i].rdot,
-                                cand[i].elev,gain,target_cn0);
+                                cand[i].elev,gain,g_target_cn0);
     }
     for(int i=0;i<new_n;++i) ch[i]=new_ch[i];
     *n = new_n;
@@ -202,7 +203,7 @@ void generate_signal(const sim_config_t *cfg)
         double dx=sat[0]-usr.xyz[0],dy=sat[1]-usr.xyz[1],dz=sat[2]-usr.xyz[2];
         double rho=hypot(hypot(dx,dy),dz);
         double rdot=(dx*(vel[0]-uvel[0]) + dy*(vel[1]-uvel[1]) + dz*(vel[2]-uvel[2]))/rho;
-        update_channel_dynamics(&ch[i],rho,rdot,el,cfg->gain,cfg->target_cn0);
+        update_channel_dynamics(&ch[i],rho,rdot,el,cfg->gain,g_target_cn0);
         printf("[ch%02d] rdot %.2f fd %.2fHz\n", ch[i].prn, rdot, ch[i].fd);
     }
 
@@ -269,7 +270,7 @@ void generate_signal(const sim_config_t *cfg)
         }
 
         update_channels_dynamic(ch,&n_ch,&usr,uvel,cfg->gain,
-                                cfg->target_cn0,cfg->geo_first,
+                                g_target_cn0,cfg->geo_first,
                                 cfg->single_prn,cfg->no_geo);
 
         /* --- STEP_MS 次 1ms 取樣 --- */

--- a/channel.c
+++ b/channel.c
@@ -10,6 +10,9 @@
 #define FCARRIER   1561.098e6      /* B1I */
 #define CHIPRATE   2.046e6
 static double fs = 5.120e6;           /* default sample rate */
+
+/* default target CN0, overridable via CLI */
+double g_target_cn0 = 42.0;
 #define DBM_REF   (-130.0)         /* ±1.0 → –130 dBm */
 
 /* ---- Receiver antenna pattern (0° boresight) ---- */
@@ -126,6 +129,8 @@ double calc_amp(int prn,double rho,double gain,double target_cn0)
     double cn0_dbhz  = p_dbm - DBM_REF + 10.0*log10(fs);
     double diff_db   = target_cn0 - cn0_dbhz;
     double a         = pow(10.0,diff_db/20.0) * 16384.0;
+    if (a > 32760.0) a = 32760.0;   /* clip upper bound */
+    if (a < 1.0)     a = 1.0;       /* clip lower bound */
     return gain * a;
 }
 

--- a/channel.h
+++ b/channel.h
@@ -39,6 +39,9 @@ int  is_d2_prn(int prn);
 int  is_igso_prn(int prn);
 int  is_meo_prn(int prn);
 
+/* Global target CN0 (dB-Hz) */
+extern double g_target_cn0;
+
 /* === 修正：用指標而非 array declarator === */
 void get_subframe_bits(int prn, int sf_id, int week, double sow,
                        double frame_len, uint8_t *out);   /* out[300] */

--- a/main.c
+++ b/main.c
@@ -8,6 +8,7 @@
 #include "timeconv.h"
 #include "globals.h"
 #include "path.h"
+#include "channel.h"        /* g_target_cn0 */
 
 /* ───────────────────────────── */
 static void usage(const char *p)
@@ -21,6 +22,7 @@ static void usage(const char *p)
     puts("  --duration sec       模擬秒數 (1-3600)");
     puts("  --gain amp           輸出增益 (>0)");
     puts("  --noise stddev       加入 AWGN 雜訊標準差");
+    puts("  -cn0 value          目標 CN0 (dB-Hz)");
     puts("  --seed n            雜訊亂數種子 (整數)");
     puts("  --byte               輸出 I-only 之 8-bit 檔");
     puts("  --geo-first          優先可見 GEO 衛星");
@@ -49,6 +51,16 @@ int main(int argc,char *argv[])
     for(int i=1;i<argc;i++){
         if(strcmp(argv[i],"-byte")==0)
             argv[i] = "--byte";
+    }
+
+    /* Handle legacy -cn0 option */
+    for(int k=1;k<argc;k++){
+        if(!strcmp(argv[k], "-cn0") && k + 1 < argc){
+            g_target_cn0 = atof(argv[k+1]);
+            for(int j=k;j+2<=argc;j++) argv[j]=argv[j+2];
+            argc -= 2;
+            k--;
+        }
     }
 
     /* 2. 解析 CLI ----------------------------------- */


### PR DESCRIPTION
## Summary
- expose global `g_target_cn0` in `channel.h`
- implement default target CN0 and clipping in `channel.c`
- use `g_target_cn0` for channel initialisation and updates
- parse legacy `-cn0` option in `main.c`

## Testing
- `make`
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_688a1223f7e48327b0f994673073d105