### PR TITLE
Remove dynamic channel switching

### DIFF
--- a/bdssim.c
+++ b/bdssim.c
@@ -109,49 +109,26 @@ int select_channels(channel_t *ch,int *n,const coord_t*u,
     return *n;
 }
 
-/* 更新當前可見通道（可動態加入/移除） */
-static void update_channels_dynamic(channel_t *ch,int *n,const coord_t *u,
-                                    const double uvel[3],double gain,double target_cn0,
-                                    bool geo_first,int single_prn,bool no_geo)
+/* 更新通道但保留原始 PRN，不做重新選擇 */
+static void update_channels_fixed(channel_t *ch,int n,const coord_t *u,
+                                  const double uvel[3],double gain,double target_cn0)
 {
-    (void)target_cn0; /* now using global g_target_cn0 */
-    struct cand{int prn;double elev,rho,rdot;int pri;} cand[63];
-    int m=0;
     double uv[3];
-    if(uvel) { uv[0]=uvel[0]; uv[1]=uvel[1]; uv[2]=uvel[2]; }
-    else { uv[0]=uv[1]=uv[2]=0.0; }
-    for(int prn=1;prn<=63;++prn){
-        if(single_prn>0 && prn!=single_prn) continue;
-        if(no_geo && is_d2_prn(prn)) continue;
-        double sat[3],vel[3];
+    if(uvel){ uv[0]=uvel[0]; uv[1]=uvel[1]; uv[2]=uvel[2]; }
+    else     { uv[0]=uv[1]=uv[2]=0.0; }
+
+    for(int i=0;i<n;++i){
+        int prn = ch[i].prn;
+        double sat[3], vel[3];
         calc_sat_position_velocity(prn,u->week,u->sow,sat,vel);
         double enu[3]; ecef2enu(u,sat,enu);
-        double el=enu_elevation_deg(enu); if(el<5.0) continue;
+        double el = enu_elevation_deg(enu);
         double dx=sat[0]-u->xyz[0], dy=sat[1]-u->xyz[1], dz=sat[2]-u->xyz[2];
         double rho=hypot(hypot(dx,dy),dz);
         double rdot=(dx*(vel[0]-uv[0]) + dy*(vel[1]-uv[1]) + dz*(vel[2]-uv[2]))/rho;
-        int pri = (geo_first && is_d2_prn(prn)) ? 1 : 0;
-        cand[m++] = (struct cand){prn,el,rho,rdot,pri};
+        update_channel_dynamics(&ch[i],rho,rdot,el,gain,target_cn0);
+        if(el < 5.0) ch[i].amp = 0.0;     /* below horizon → mute */
     }
-    for(int i=0;i<m-1;++i) for(int j=i+1;j<m;++j){
-        if(cand[j].pri>cand[i].pri ||
-           (cand[j].pri==cand[i].pri && cand[j].elev>cand[i].elev)){
-            struct cand t=cand[i];cand[i]=cand[j];cand[j]=t;
-        }
-    }
-
-    int new_n = m<MAX_CH?m:MAX_CH;
-    channel_t new_ch[MAX_CH];
-    for(int i=0;i<new_n;++i){
-        int idx=-1;
-        for(int j=0;j<*n;++j) if(ch[j].prn==cand[i].prn){ idx=j; break; }
-        if(idx>=0) new_ch[i]=ch[idx];
-        else       channel_reset(&new_ch[i],cand[i].prn,u->week,u->sow);
-        update_channel_dynamics(&new_ch[i],cand[i].rho,cand[i].rdot,
-                                cand[i].elev,gain,g_target_cn0);
-    }
-    for(int i=0;i<new_n;++i) ch[i]=new_ch[i];
-    *n = new_n;
 }
 /*----------------------------------------------------*/
 void generate_signal(const sim_config_t *cfg)
@@ -269,9 +246,8 @@ void generate_signal(const sim_config_t *cfg)
             uvel[2]=(cur_eci[2]-prev_eci[2])/dt;
         }
 
-        update_channels_dynamic(ch,&n_ch,&usr,uvel,cfg->gain,
-                                g_target_cn0,cfg->geo_first,
-                                cfg->single_prn,cfg->no_geo);
+        update_channels_fixed(ch,n_ch,&usr,uvel,
+                              cfg->gain,g_target_cn0);
 
         /* --- STEP_MS 次 1ms 取樣 --- */
         for(int step=0;step<STEP_MS;++step){


### PR DESCRIPTION
## Summary
- add `update_channels_fixed` helper
- keep initial PRN assignments and mute satellites below 5° elevation

## Testing
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_688a1c942d608327a7fc457d8f546eb0