### PR TITLE
Implement CN0 headroom settings and sample rate update

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ tool computes the user position (static or from a path file), derives
 satellite geometry and Doppler, and updates the channel state. The
 navigation message for subframes 1–5 is generated with correct
 time-of-week. Each channel spreads the bits with its PRN code and the
-samples are summed into a 16‑bit I/Q stream at a fixed 5.120 MHz sample
+samples are summed into a 16‑bit I/Q stream at a fixed 6.144 MHz sample
 rate.
 
 ## Build
@@ -57,7 +57,7 @@ Run `make check` to build and execute the self test
 
 The build produces `bds-sim` which outputs a signed `beidou_b1i.bin`
 file containing interleaved **16‑bit little‑endian** I/Q samples. By
-default the file is written at **5.120 MHz**.  Each sample is a pair of
+default the file is written at **6.144 MHz**.  Each sample is a pair of
 16‑bit integers `(I,Q)` so be
 careful not to interpret the file as 8‑bit data—otherwise the Q channel
 may appear to contain only zeros or `-1` values.
@@ -187,7 +187,7 @@ This builds and runs `tests/test_prn_d1d2` to verify D1/D2 generation.
 ## SDR playback
 
 The file `beidou_b1i.bin` contains interleaved **16‑bit little‑endian**
-I/Q samples written at a fixed **5.120 MHz** sample rate.
+I/Q samples written at a fixed **6.144 MHz** sample rate.
 Ensure any analysis or playback software reads the file as 16‑bit
 integers; using 8‑bit interpretation will yield
 Q samples that look like zeros.
@@ -222,7 +222,7 @@ searches for the correct PRNs automatically.
 * Fix UTC→BDT +4 s
 * GEO satellites enabled
 * Added subframe 4/5 template
-* Default Fs → 5.120 MHz
+* Default Fs → 6.144 MHz
 * Power scaling by target CN₀
 * Basic D2 (500 bps) support with D1 interleaving
 

--- a/bdssim.c
+++ b/bdssim.c
@@ -14,7 +14,7 @@
 #include "path.h"
 #include "globals.h"     /* nav_week */
 #define OMEGA_E   7.2921150e-5
-#define FSAMP_DEF 5.120e6    /* default 5.120 MHz for 16-bit I/Q output */
+#define FSAMP_DEF FS_OUTPUT_HZ    /* default 6.144 MHz for 16-bit I/Q output */
 #define FSAMP_BYTE 25.0e6    /* 25 MHz when --byte is used */
 
 
@@ -31,6 +31,14 @@ static double gauss_rand(void)
     next=r*sin(theta);
     have=1;
     return r*cos(theta);
+}
+
+/* ========= 振幅計算與 int16 飽和保護 ========= */
+static inline int16_t saturate_int16(double x)
+{
+    if (x >  32760.0) return  32760;
+    if (x < -32760.0) return -32760;
+    return (int16_t)llround(x);
 }
 
 /* ---- 檢查模擬起始時間與星曆 toe 差距是否過大 ---- */
@@ -117,6 +125,7 @@ static void update_channels_fixed(channel_t *ch,int n,const coord_t *u,
     if(uvel){ uv[0]=uvel[0]; uv[1]=uvel[1]; uv[2]=uvel[2]; }
     else     { uv[0]=uv[1]=uv[2]=0.0; }
 
+    double amp_scale = 1.0 / sqrt((double)n);
     for(int i=0;i<n;++i){
         int prn = ch[i].prn;
         double sat[3], vel[3];
@@ -126,7 +135,7 @@ static void update_channels_fixed(channel_t *ch,int n,const coord_t *u,
         double dx=sat[0]-u->xyz[0], dy=sat[1]-u->xyz[1], dz=sat[2]-u->xyz[2];
         double rho=hypot(hypot(dx,dy),dz);
         double rdot=(dx*(vel[0]-uv[0]) + dy*(vel[1]-uv[1]) + dz*(vel[2]-uv[2]))/rho;
-        update_channel_dynamics(&ch[i],rho,rdot,el,gain,target_cn0);
+        update_channel_dynamics(&ch[i],rho,rdot,el,gain*amp_scale,target_cn0);
         if(el < 5.0) ch[i].amp = 0.0;     /* below horizon → mute */
     }
 }
@@ -288,8 +297,8 @@ void generate_signal(const sim_config_t *cfg)
                 if(fi>1.0)fi=1.0; else if(fi<-1.0)fi=-1.0;
                 if(fq>1.0)fq=1.0; else if(fq<-1.0)fq=-1.0;
                 if(fp){
-                    iq[2*k]   = (int16_t)lrint(fi*32767.0);
-                    iq[2*k+1] = (int16_t)lrint(fq*32767.0);
+                    iq[2*k]   = saturate_int16(fi*32767.0);
+                    iq[2*k+1] = saturate_int16(fq*32767.0);
                     sumI  += iq[2*k];
                     sumQ  += iq[2*k+1];
                     sumI2 += (double)iq[2*k]*iq[2*k];

--- a/channel.c
+++ b/channel.c
@@ -9,7 +9,7 @@
 #define PI2        6.2831853071795864769
 #define FCARRIER   1561.098e6      /* B1I */
 #define CHIPRATE   2.046e6
-static double fs = 5.120e6;           /* default sample rate */
+static double fs = FS_OUTPUT_HZ;           /* default sample rate */
 
 /* default target CN0, overridable via CLI */
 double g_target_cn0 = 42.0;
@@ -128,7 +128,7 @@ double calc_amp(int prn,double rho,double gain,double target_cn0)
     double p_dbm     = sat_eirp_dbm(prn) - path_loss;
     double cn0_dbhz  = p_dbm - DBM_REF + 10.0*log10(fs);
     double diff_db   = target_cn0 - cn0_dbhz;
-    double a         = pow(10.0,diff_db/20.0) * 16384.0;
+    double a         = pow(10.0,diff_db/20.0) * 16384.0 * HEADROOM_RATIO;
     if (a > 32760.0) a = 32760.0;   /* clip upper bound */
     if (a < 1.0)     a = 1.0;       /* clip lower bound */
     return gain * a;
@@ -164,6 +164,9 @@ void channel_set_time(channel_t *c,int week,double sow)
     c->bit_ptr = ms/20;
     c->ms_count = ms%20;
     get_subframe_bits(c->prn,c->sf_id,week,sf_start,6.0,c->nav_bits);
+    if(ms == 0){
+        c->code_phase = 0.0; /* PRN 2046 chip 從頭開始 */
+    }
 
     double sf_start_d2 = floor(sow/0.6)*0.6;      /* 每 0.6 s 一個子帧 */
     double mf_start_d2 = floor(sow/3.0)*3.0;      /* 周内秒对齐到 3 s 主帧 */

--- a/globals.h
+++ b/globals.h
@@ -4,6 +4,11 @@
 #include <stdint.h>
 #include "bdssim.h"          /* 已含 MAX_SAT、CODE_LEN、ephemeris_t */
 
+/* === CN0 / NH20 全域設定 === */
+#define CN0_TARGET_DBHZ   42.0     /* 目標載波-雜訊比；40~45 均可 */
+#define HEADROOM_RATIO    0.8      /* -2 dB 的峰值餘量 */
+#define FS_OUTPUT_HZ      6144000  /* 6.144 MHz = 2.046 MHz × 3 */
+
 /* 由 globals.c 定義 */
 extern uint8_t      prn_code[MAX_SAT][CODE_LEN];
 extern ephemeris_t  eph[MAX_SAT];


### PR DESCRIPTION
## Summary
- define CN0 and sample rate constants in `globals.h`
- update channel sample rate usage and amplitude headroom
- scale per-channel gain with satellite count
- add int16 saturation helper and use it for output
- adjust default sampling rate to 6.144 MHz
- refresh README accordingly
- keep `gpssim.c` unchanged

## Testing
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_688b91c7579083278c8bade1b666d6d7