### PR TITLE
Sync sampling rate constant across codebase

### DIFF
--- a/main.c
+++ b/main.c
@@ -240,7 +240,7 @@ int main(int argc,char *argv[])
            usr.xyz[0], usr.xyz[1], usr.xyz[2]);
     printf("[cfg] PRN:");
     for(int i=0;i<n_ch;i++) printf(" %02d", ch[i].prn);
-    double fs_out = cfg.byte_output ? 25.0 : 5.12;
+    double fs_out = cfg.byte_output ? 25.0 : FS_OUTPUT_HZ/1e6;
     printf("  Fs %.2fMHz  Gain %.2f\n\n",
            fs_out, cfg.gain);
 

--- a/tests/test_d2_cycles.c
+++ b/tests/test_d2_cycles.c
@@ -22,9 +22,9 @@ int main(void)
     ch.carr_phase = 0.0;
     ch.code_phase = 0.1; /* avoid boundary ambiguity */
     update_channel_dynamics(&ch, 2.0e7, 0.0, 90.0, 1.0, cfg.target_cn0);
-    channel_set_fs(5.12e6);
+    channel_set_fs(FS_OUTPUT_HZ);
 
-    int samp_per_ms = (int)(5.12e6/1000.0 + 0.5);
+    int samp_per_ms = (int)(FS_OUTPUT_HZ/1000.0 + 0.5);
     int16_t I[samp_per_ms], Q[samp_per_ms];
 
     /* generate 2 ms and verify D2 bit spans two PRN cycles */

--- a/tests/test_nh_prn.c
+++ b/tests/test_nh_prn.c
@@ -22,9 +22,9 @@ int main(void)
     ch.carr_phase = 0.0;
     ch.code_phase = 0.1; /* avoid boundary ambiguity */
     update_channel_dynamics(&ch, 2.0e7, 0.0, 90.0, 1.0, cfg.target_cn0);
-    channel_set_fs(5.12e6);
+    channel_set_fs(FS_OUTPUT_HZ);
 
-    int samp_per_ms = (int)(5.12e6/1000.0 + 0.5);
+    int samp_per_ms = (int)(FS_OUTPUT_HZ/1000.0 + 0.5);
     int16_t I[samp_per_ms], Q[samp_per_ms];
 
     /* generate 20 ms and verify NH/PRN relationship */

--- a/tests/test_prn_d1d2.c
+++ b/tests/test_prn_d1d2.c
@@ -20,8 +20,8 @@ int main(void){
     channel_t c3, c8;
     channel_reset(&c3, 3, nav_week, 0.0);
     channel_reset(&c8, 8, nav_week, 0.0);
-    channel_set_fs(5.12e6);
-    int samp_per_ms = (int)(5.12e6/1000.0 + 0.5);
+    channel_set_fs(FS_OUTPUT_HZ);
+    int samp_per_ms = (int)(FS_OUTPUT_HZ/1000.0 + 0.5);
     int16_t I[samp_per_ms], Q[samp_per_ms];
 
     for(int i=0;i<10;i++){


### PR DESCRIPTION
## Summary
- ensure tests and main program use the updated sampling rate constant instead of the old 5.12 MHz value

## Testing
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_688df29f42d883279917653c12e3a5bc