### PR TITLE
Improve D1 and D2 timing alignment and clip monitoring

### DIFF
--- a/bdssim.c
+++ b/bdssim.c
@@ -197,6 +197,7 @@ void generate_signal(const sim_config_t *cfg)
     int32_t accI[samp_per_ms],accQ[samp_per_ms];
     double sumI=0.0,sumQ=0.0,sumI2=0.0,sumQ2=0.0;
     uint64_t samp_cnt=0;
+    static uint64_t clip_cnt = 0, tot_cnt = 0;
 
     const int STEP_MS = cfg->step_ms;
     const uint64_t total_ms=(uint64_t)cfg->duration*1000;
@@ -277,6 +278,8 @@ void generate_signal(const sim_config_t *cfg)
                 if(fi>1.0)fi=1.0; else if(fi<-1.0)fi=-1.0;
                 if(fq>1.0)fq=1.0; else if(fq<-1.0)fq=-1.0;
                 if(fp){
+                    if (fi>=0.999969 || fi<=-0.999969 || fq>=0.999969 || fq<=-0.999969) clip_cnt++;
+                    tot_cnt++;
                     iq[2*k]   = saturate_int16(fi*32767.0);
                     iq[2*k+1] = saturate_int16(fq*32767.0);
                     sumI  += iq[2*k];
@@ -294,6 +297,11 @@ void generate_signal(const sim_config_t *cfg)
                 fwrite(iq,sizeof(int16_t),2*samp_per_ms,fp);
             else
                 fwrite(i8,sizeof(int8_t),samp_per_ms,fp8);
+            /* 每秒印一次 clipping 比例 */
+            if (((int)(step+1))%1000==0 && fp){
+                fprintf(stderr,"[stat] clip=%.5f%%\n", 100.0*(double)clip_cnt/(double)tot_cnt);
+                clip_cnt=tot_cnt=0;
+            }
 
         }
         /* 進度顯示 */

--- a/channel.c
+++ b/channel.c
@@ -31,7 +31,10 @@ static double antenna_gain(double elev_deg)
 {
     int idx=(int)((90.0-elev_deg)/5.0);
     if(idx<0) idx=0; else if(idx>36) idx=36;
-    return ant_pat[idx];
+    /* 建議先把接收端天線圖改成「最多 -6 dB」的溫和版本做驗證 */
+    double g = ant_pat[idx];
+    if (g < pow(10.0,-6.0/20.0)) g = pow(10.0,-6.0/20.0);
+    return g;
 }
 
 /* simple multipath loss model: -3 dB below 15° elevation */
@@ -129,7 +132,8 @@ double calc_amp(int prn,double rho,double gain,double target_cn0)
     double cn0_dbhz  = p_dbm - DBM_REF + 10.0*log10(fs);
     double diff_db   = target_cn0 - cn0_dbhz;
     double a         = pow(10.0,diff_db/20.0) * 16384.0 * HEADROOM_RATIO;
-    if (a > 32760.0) a = 32760.0;   /* clip upper bound */
+    /* 單星硬帽：確保單星 cos/sin 相乘後仍不會觸頂 */
+    if (a > 20000.0) a = 20000.0;
     if (a < 1.0)     a = 1.0;       /* clip lower bound */
     return gain * a;
 }
@@ -165,7 +169,10 @@ void channel_set_time(channel_t *c,int week,double sow)
     c->ms_count = ms%20;
     get_subframe_bits(c->prn,c->sf_id,week,sf_start,6.0,c->nav_bits);
     if(ms == 0){
-        c->code_phase = 0.0; /* PRN 2046 chip 從頭開始 */
+        /* 在子幀邊界，強制對齊三個時序：PRN、NH20、NAV */
+        c->code_phase = 0.0;     /* 1 ms PRN 2046 chips 從頭開始 */
+        c->ms_count   = 0;       /* NH20 index 從 0 開始 */
+        c->bit_ptr    = 0;       /* 50 bps NAV bit 從 0 開始 */
     }
 
     double sf_start_d2 = floor(sow/0.6)*0.6;      /* 每 0.6 s 一個子帧 */
@@ -178,6 +185,12 @@ void channel_set_time(channel_t *c,int week,double sow)
     c->ms_count_d2 = ms2%2;
     /* D2 的 SOW 以主帧(3 s) 的子帧1同步頭對齊 */
     get_subframe_bits(c->prn,c->sf_id_d2,week,mf_start_d2,3.0,c->nav_bits_d2);
+    /* 只在 3 s 主帧邊界重置 D2 的碼相位與導航索引 */
+    if(is_d2_prn(c->prn) && fabs(sow - mf_start_d2) < 1e-9){
+        c->code_phase  = 0.0;
+        c->bit_ptr_d2  = 0;
+        c->ms_count_d2 = 0;
+    }
 }
 
 void channel_reset(channel_t *c,int prn,int week,double sow){


### PR DESCRIPTION
## Summary
- Reset PRN, NH20, and NAV state at each 6 s boundary to keep D1 timing aligned
- Soften receiver antenna pattern and hard-cap per-satellite amplitude
- Track output clipping and report a per-second statistic
- For D2 channels, reset code and navigation counters only when starting on a 3 s master-frame boundary

## Testing
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_688e00d0b3bc83279ca523ac5be09e4a