### PR TITLE
Adjust channel count and PRN output

### DIFF
--- a/bdssim.h
+++ b/bdssim.h
@@ -9,7 +9,7 @@
 /* ---------- 常數 ---------- */
 #define MAX_SAT      65
 #define MAX_PRN_LEN  CODE_LEN
-#define MAX_CH       12        /* 最多同時播 12 顆 */
+#define MAX_CH       8         /* 最多同時播 8 顆 */
 
 /* ---------- 星曆結構 (僅用到的欄位) ---------- */
 typedef struct {

--- a/channel.h
+++ b/channel.h
@@ -3,7 +3,7 @@
 #define CHANNEL_H
 #include <stdint.h>
 
-#define MAX_CH     12
+#define MAX_CH     8
 #define CODE_LEN   2046
 
 typedef struct {

--- a/globals.h
+++ b/globals.h
@@ -10,7 +10,7 @@
 #define HEADROOM_RATIO    0.80        /* 約 -2 dB 頭房，防飽和 */
 #define AMP_SMOOTH_TC_MS  1000        /* 振幅平滑時間常數 */
 /* Per-orbit-class amplitude offsets (dB) */
-#define GAIN_MEO_DB    0.0
+#define GAIN_MEO_DB   +1.5
 #define GAIN_IGSO_DB  +1.5
 #define GAIN_GEO_DB   -3.0
 

--- a/main.c
+++ b/main.c
@@ -228,10 +228,29 @@ int main(int argc,char *argv[])
            usr.llh[0], usr.llh[1], usr.llh[2]);
     printf("[cfg] XYZ %.3f %.3f %.3f (m)\n",
            usr.xyz[0], usr.xyz[1], usr.xyz[2]);
+    int prn_sorted[MAX_CH];
+    for(int i=0;i<n_ch;i++) prn_sorted[i] = ch[i].prn;
+    for(int i=0;i<n_ch-1;i++)
+        for(int j=i+1;j<n_ch;j++)
+            if(prn_sorted[j] < prn_sorted[i]){
+                int t = prn_sorted[i];
+                prn_sorted[i] = prn_sorted[j];
+                prn_sorted[j] = t;
+            }
     printf("[cfg] PRN:");
-    for(int i=0;i<n_ch;i++) printf(" %02d", ch[i].prn);
+    for(int i=0;i<n_ch;i++) printf(" %02d", prn_sorted[i]);
+    printf("\n[cfg] GEO:");
+    for(int i=0;i<n_ch;i++)
+        if(!is_igso_prn(prn_sorted[i]) && !is_meo_prn(prn_sorted[i]))
+            printf(" %02d", prn_sorted[i]);
+    printf("\n[cfg] IGSO:");
+    for(int i=0;i<n_ch;i++)
+        if(is_igso_prn(prn_sorted[i])) printf(" %02d", prn_sorted[i]);
+    printf("\n[cfg] MEO:");
+    for(int i=0;i<n_ch;i++)
+        if(is_meo_prn(prn_sorted[i])) printf(" %02d", prn_sorted[i]);
     double fs_out = cfg.byte_output ? 25.0 : FS_OUTPUT_HZ/1e6;
-    printf("  Fs %.2fMHz  Gain %.2f\n\n",
+    printf("\n[cfg] Fs %.2fMHz  Gain %.2f\n\n",
            fs_out, cfg.gain);
 
     /* 4. 產生基帶 ----------------------------------- */


### PR DESCRIPTION
## Summary
- limit simulator to 8 concurrent channels
- match MEO gain with IGSO
- report PRNs sorted with GEO/IGSO/MEO breakdown

## Testing
- `make check`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_688e18239ef883279d13f6090e84c291