### PR TITLE
Add phase debug dump and fix clipping stats

### DIFF
--- a/bdssim.c
+++ b/bdssim.c
@@ -163,6 +163,7 @@ void generate_signal(const sim_config_t *cfg)
     double sumI=0.0,sumQ=0.0,sumI2=0.0,sumQ2=0.0;
     uint64_t samp_cnt=0;
     static uint64_t clip_cnt = 0, tot_cnt = 0;
+    uint64_t ms_counter = 0;  /* for 1 ms pacing stats */
 
     const int STEP_MS = cfg->step_ms;
     const uint64_t total_ms=(uint64_t)cfg->duration*1000;
@@ -273,8 +274,9 @@ void generate_signal(const sim_config_t *cfg)
                 fwrite(iq,sizeof(int16_t),2*samp_per_ms,fp);
             else
                 fwrite(i8,sizeof(int8_t),samp_per_ms,fp8);
-            /* 每秒印一次 clipping 比例 */
-            if (((int)(step+1))%1000==0 && fp){
+            /* 每秒印一次 clipping 比例（以 1 ms 計數） */
+            ms_counter++;
+            if (fp && (ms_counter % 1000ULL)==0) {
                 fprintf(stderr,"[stat] clip=%.5f%%\n", 100.0*(double)clip_cnt/(double)tot_cnt);
                 clip_cnt=tot_cnt=0;
             }

--- a/channel.c
+++ b/channel.c
@@ -2,6 +2,7 @@
 #include <string.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <stdio.h>
 #include <math.h>
 #include "channel.h"
 #include "globals.h"               /* prn_code */
@@ -241,6 +242,13 @@ void update_channel_dynamics_10hz(channel_t *c, int week, double sow,
     /* 保留顯示用值 */
     c->fd        = fd0;
     c->code_rate = R0;
+#ifdef DEBUG_DUMP_PHASE
+    if (fabs(fmod(sow, 1.0)) < 1e-6) {
+        fprintf(stderr,
+                "[dbg] PRN%02d fd=%.1fHz R=%.1f cps phase=%.3frad\n",
+                c->prn, c->f_inst, c->R_inst, c->carr_phase);
+    }
+#endif
 }
 void channel_set_fs(double sample_rate)
 {


### PR DESCRIPTION
## Summary
- add optional phase/Doppler debug dump every second when `DEBUG_DUMP_PHASE` is defined
- fix clipping statistics to use ms counter for accurate per-second reporting

## Testing
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_688e40a1b5fc8327b1ffe66783e0b80c