### PR TITLE
Implement 10 Hz geometry updates with smooth interpolation

### DIFF
--- a/bdssim.c
+++ b/bdssim.c
@@ -16,6 +16,8 @@
 #define OMEGA_E   7.2921150e-5
 #define FSAMP_DEF FS_OUTPUT_HZ    /* default 6.144 MHz for 16-bit I/Q output */
 #define FSAMP_BYTE 25.0e6    /* 25 MHz when --byte is used */
+#define FCARRIER   1561.098e6      /* B1I carrier */
+#define CHIPRATE   2.046e6
 
 /* ========= 振幅計算與 int16 飽和保護 ========= */
 static inline int16_t saturate_int16(double x)
@@ -103,11 +105,14 @@ int select_channels(channel_t *ch,int *n,const coord_t*u,
 
 /* 更新通道但保留原始 PRN，不做重新選擇 */
 static void update_channels_fixed(channel_t *ch,int n,const coord_t *u,
-                                  const double uvel[3],double gain,double target_cn0)
+                                  const double uvel[3],double gain,double target_cn0,
+                                  int step_ms)
 {
     double uv[3];
     if(uvel){ uv[0]=uvel[0]; uv[1]=uvel[1]; uv[2]=uvel[2]; }
     else     { uv[0]=uv[1]=uv[2]=0.0; }
+
+    double dt = step_ms * 0.001; /* seconds */
 
     for(int i=0;i<n;++i){
         int prn = ch[i].prn;
@@ -118,8 +123,25 @@ static void update_channels_fixed(channel_t *ch,int n,const coord_t *u,
         double dx=sat[0]-u->xyz[0], dy=sat[1]-u->xyz[1], dz=sat[2]-u->xyz[2];
         double rho=hypot(hypot(dx,dy),dz);
         double rdot=(dx*(vel[0]-uv[0]) + dy*(vel[1]-uv[1]) + dz*(vel[2]-uv[2]))/rho;
-        update_channel_dynamics(&ch[i],rho,rdot,el,gain,target_cn0,n);
+        update_channel_dynamics(&ch[i],rho,rdot,el,gain,target_cn0,n,step_ms);
         if(el < 5.0) ch[i].amp = 0.0;     /* below horizon → mute */
+
+        /* predict next dynamics for linear interpolation */
+        double u_next[3]={u->xyz[0]+uv[0]*dt,
+                          u->xyz[1]+uv[1]*dt,
+                          u->xyz[2]+uv[2]*dt};
+        double sat2[3], vel2[3];
+        double t_abs = u->week*604800.0 + u->sow + dt;
+        int week2 = (int)(t_abs/604800.0);
+        double sow2 = t_abs - week2*604800.0;
+        calc_sat_position_velocity(prn,week2,sow2,sat2,vel2);
+        double dx2=sat2[0]-u_next[0], dy2=sat2[1]-u_next[1], dz2=sat2[2]-u_next[2];
+        double rho2=hypot(hypot(dx2,dy2),dz2);
+        double rdot2=(dx2*(vel2[0]-uv[0]) + dy2*(vel2[1]-uv[1]) + dz2*(vel2[2]-uv[2]))/rho2;
+        double fd2 = -FCARRIER*rdot2/299792458.0;
+        double cr2 = CHIPRATE*(1.0 - rdot2/299792458.0);
+        ch[i].fd_dot = (fd2 - ch[i].fd) / dt;
+        ch[i].code_rate_dot = (cr2 - ch[i].code_rate) / dt;
     }
 }
 /*----------------------------------------------------*/
@@ -161,20 +183,6 @@ void generate_signal(const sim_config_t *cfg)
     double fs = cfg->byte_output ? FSAMP_BYTE : FSAMP_DEF;
     int samp_per_ms = (int)(fs/1000.0 + 0.5);
     channel_set_fs(fs);                   /* ensure dynamics use correct Fs */
-
-    double uvel[3]={-OMEGA_E*usr.xyz[1], OMEGA_E*usr.xyz[0], 0.0};
-    /* 首次幾何 – 初始化振幅/NCO */
-    for(int i=0;i<n_ch;++i){
-        double sat[3],vel[3];
-        calc_sat_position_velocity(ch[i].prn,usr.week,usr.sow,sat,vel);
-        double enu[3]; ecef2enu(&usr,sat,enu);
-        double el=enu_elevation_deg(enu);
-        double dx=sat[0]-usr.xyz[0],dy=sat[1]-usr.xyz[1],dz=sat[2]-usr.xyz[2];
-        double rho=hypot(hypot(dx,dy),dz);
-        double rdot=(dx*(vel[0]-uvel[0]) + dy*(vel[1]-uvel[1]) + dz*(vel[2]-uvel[2]))/rho;
-        update_channel_dynamics(&ch[i],rho,rdot,el,cfg->gain,g_target_cn0,n_ch);
-        printf("[ch%02d] rdot %.2f fd %.2fHz\n", ch[i].prn, rdot, ch[i].fd);
-    }
 
     FILE *fp=NULL, *fp8=NULL;
     if(cfg->byte_output){
@@ -240,7 +248,13 @@ void generate_signal(const sim_config_t *cfg)
         }
 
         update_channels_fixed(ch,n_ch,&usr,uvel,
-                              cfg->gain,g_target_cn0);
+                              cfg->gain,g_target_cn0,STEP_MS);
+        if(ms==0){
+            for(int i=0;i<n_ch;++i){
+                double rdot = -ch[i].fd*299792458.0/FCARRIER;
+                printf("[ch%02d] rdot %.2f fd %.2fHz\n", ch[i].prn, rdot, ch[i].fd);
+            }
+        }
 
         /* --- STEP_MS 次 1ms 取樣 --- */
         for(int step=0;step<STEP_MS;++step){

--- a/channel.c
+++ b/channel.c
@@ -101,10 +101,9 @@ static inline double orbit_gain_amp(int prn)
 }
 
 /* 指數平滑振幅，避免 AM 旁帶 */
-static inline double smooth_amp(double A_prev, double A_new)
+static inline double smooth_amp(double A_prev, double A_new, double dt_ms)
 {
-    /* Called every 1 ms, so dt = 1 ms; use time constant in milliseconds */
-    double alpha = 1.0 - exp(-1.0 / AMP_SMOOTH_TC_MS);
+    double alpha = 1.0 - exp(-dt_ms / AMP_SMOOTH_TC_MS);
     if (A_prev == 0.0)
         return A_new;                  /* avoid long ramp at start */
     return A_prev + alpha * (A_new - A_prev);
@@ -179,14 +178,15 @@ void channel_reset(channel_t *c,int prn,int week,double sow){
 }
 /* 幾何→計算振幅 / 初始多普勒 */
 void update_channel_dynamics(channel_t *c,double rho,double rdot,double elev_deg,
-                             double gain,double target_cn0,int n_visible)
+                             double gain,double target_cn0,int n_visible,
+                             double dt_ms)
 {
     (void)rho; /* rho currently unused in simplified amplitude model */
     double base = amp_from_cn0(target_cn0, n_visible);
     double s = sin(elev_deg * (M_PI/180.0));
     if (s < 0.0) s = 0.0;
     double A_new = base * orbit_gain_amp(c->prn) * pow(s, 1.2) * gain;
-    c->amp = smooth_amp(c->amp, A_new);
+    c->amp = smooth_amp(c->amp, A_new, dt_ms);
     c->elev_deg = elev_deg;
     c->fd  = -FCARRIER*rdot/299792458.0;               /* Doppler (Hz) */
     c->code_rate = CHIPRATE*(1.0 - rdot/299792458.0);  /* Code frequency (Hz) */
@@ -204,11 +204,12 @@ void gen_samples_1ms(channel_t *c,int week,double sow,
     if(c->bit_ptr==0 && c->ms_count==0)
         get_subframe_bits(c->prn,c->sf_id,week,sow,6.0,c->nav_bits);
 
-    /* Baseband output – only apply Doppler frequency */
-    const double dphi = PI2*c->fd/fs;
-    const double dcode = c->code_rate/fs;     /* chips per sample */
-    double code_phase = c->code_phase;
+    double fd = c->fd;
+    double code_rate = c->code_rate;
     double phase = c->carr_phase;
+    double code_phase = c->code_phase;
+    double dfd = c->fd_dot / fs;
+    double dcode_rate = c->code_rate_dot / fs;
 
     for(int n=0;n<samp_per_ms;++n){
         int chip = (int)code_phase;            /* 0..2045 */
@@ -220,11 +221,12 @@ void gen_samples_1ms(channel_t *c,int week,double sow,
         I[n]=(int16_t)lrintf(s*co);
         Q[n]=(int16_t)lrintf(s*si);
 
-        /* NCO */
-        phase += dphi;
+        phase += PI2*fd/fs;
+        fd += dfd;
         if(phase>=PI2)      phase-=PI2;
         else if(phase<0.0)  phase+=PI2;
-        code_phase += dcode;
+        code_phase += code_rate/fs;
+        code_rate += dcode_rate;
         if(code_phase>=CODE_LEN){
             code_phase-=CODE_LEN;
             if(++c->ms_count==20){
@@ -236,6 +238,8 @@ void gen_samples_1ms(channel_t *c,int week,double sow,
             }
         }
     }
+    c->fd = fd;
+    c->code_rate = code_rate;
     c->carr_phase = phase;
     c->code_phase = code_phase;
 }
@@ -253,10 +257,12 @@ void gen_samples_1ms_d2(channel_t *c, int week, double sow,
         get_subframe_bits(c->prn,c->sf_id_d2,week,mf_start_d2,3.0,c->nav_bits_d2);
     }
 
-    const double dphi = PI2*c->fd/fs;
-    const double dcode = c->code_rate/fs;
-    double code_phase = c->code_phase;
+    double fd = c->fd;
+    double code_rate = c->code_rate;
     double phase = c->carr_phase;
+    double code_phase = c->code_phase;
+    double dfd = c->fd_dot / fs;
+    double dcode_rate = c->code_rate_dot / fs;
 
     for(int n=0;n<samp_per_ms;++n){
         int chip = (int)code_phase;
@@ -267,14 +273,18 @@ void gen_samples_1ms_d2(channel_t *c, int week, double sow,
         I[n]=(int16_t)lrintf(s*co);
         Q[n]=(int16_t)lrintf(s*si);
 
-        phase += dphi;
+        phase += PI2*fd/fs;
+        fd += dfd;
         if(phase>=PI2)      phase-=PI2;
         else if(phase<0.0)  phase+=PI2;
-        code_phase += dcode;
+        code_phase += code_rate/fs;
+        code_rate += dcode_rate;
         if(code_phase>=CODE_LEN){
             code_phase-=CODE_LEN;
         }
     }
+    c->fd = fd;
+    c->code_rate = code_rate;
     c->carr_phase = phase;
     c->code_phase = code_phase;
 

--- a/channel.h
+++ b/channel.h
@@ -10,7 +10,9 @@ typedef struct {
     int     prn;
     double  amp;
     double  fd;           /* Doppler                   */
+    double  fd_dot;       /* Doppler rate (Hz/s)       */
     double  code_rate;    /* chipping rate             */
+    double  code_rate_dot;/* chipping rate slope       */
     double  carr_phase;   /* rad                       */
     double  code_phase;   /* chips                     */
     double  elev_deg;     /* satellite elevation (deg) */
@@ -30,7 +32,8 @@ void channel_reset(channel_t *, int prn, int week, double sow);
 void channel_set_time(channel_t *, int week, double sow);
 void update_channel_dynamics(channel_t *, double rho, double rdot,
                              double elev_deg, double gain,
-                             double target_cn0, int n_visible);
+                             double target_cn0, int n_visible,
+                             double dt_ms);
 void channel_set_fs(double sample_rate);
 void gen_samples_1ms(channel_t *, int week, double sow,
                      int samp_per_ms, int16_t *I, int16_t *Q);

--- a/main.c
+++ b/main.c
@@ -36,7 +36,7 @@ int main(int argc,char *argv[])
     sim_config_t cfg = {0};
     cfg.gain        = 1.0;
     cfg.target_cn0  = 45.0;            /* dB-Hz */
-    cfg.step_ms     = 1;
+    cfg.step_ms     = 100;
     cfg.duration    = 300;                /* 預設 300 秒 */
     cfg.seed        = 1;
     cfg.byte_output = false;

--- a/tests/test_d2_cycles.c
+++ b/tests/test_d2_cycles.c
@@ -21,7 +21,7 @@ int main(void)
     channel_reset(&ch, prn, nav_week, 0.0);
     ch.carr_phase = 0.0;
     ch.code_phase = 0.1; /* avoid boundary ambiguity */
-    update_channel_dynamics(&ch, 2.0e7, 0.0, 90.0, 1.0, cfg.target_cn0, 1);
+    update_channel_dynamics(&ch, 2.0e7, 0.0, 90.0, 1.0, cfg.target_cn0, 1, 1.0);
     channel_set_fs(FS_OUTPUT_HZ);
 
     int samp_per_ms = (int)(FS_OUTPUT_HZ/1000.0 + 0.5);

--- a/tests/test_nh_prn.c
+++ b/tests/test_nh_prn.c
@@ -21,7 +21,7 @@ int main(void)
     channel_reset(&ch, prn, nav_week, 0.0);
     ch.carr_phase = 0.0;
     ch.code_phase = 0.1; /* avoid boundary ambiguity */
-    update_channel_dynamics(&ch, 2.0e7, 0.0, 90.0, 1.0, cfg.target_cn0, 1);
+    update_channel_dynamics(&ch, 2.0e7, 0.0, 90.0, 1.0, cfg.target_cn0, 1, 1.0);
     channel_set_fs(FS_OUTPUT_HZ);
 
     int samp_per_ms = (int)(FS_OUTPUT_HZ/1000.0 + 0.5);


### PR DESCRIPTION
## Summary
- integrate Doppler and code-rate derivatives per sample for smooth 100 ms blocks
- propagate channel dynamics with 10 Hz steps and predict next state for interpolation
- default simulation update period set to 100 ms

## Testing
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_688e59e44d988327a5e9ec7fa7c35057