### PR TITLE
Add option to limit satellites to PRNs 1-37

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ The legacy option `-byte` is still recognised as an alias for `--byte`.
 - `--geo-first` 在挑選模擬衛星時會優先加入可見的 GEO 衛星
 - `--no-geo` 排除所有 GEO 衛星
 - `--prn`  可只輸出指定 PRN
+- `--prn37`  僅使用 1-37 號衛星
 
 MEO 與 IGSO 依據星曆中的 `sqrtA`(軌道半長軸平方根) 分辨。大於 6000 的視
 為與 GEO 相同的軌道高度，即 IGSO，否則為 MEO。

--- a/bdssim.c
+++ b/bdssim.c
@@ -32,7 +32,7 @@ static void check_ephemeris_age(int week,double sow)
 {
     double t = week*604800.0 + sow;
     int warn = 0;
-    for(int prn=1; prn<=63; ++prn){
+    for(int prn=1; prn<=prn_max; ++prn){
         if(eph[prn].prn==0) continue;
         double toe = eph[prn].week*604800.0 + eph[prn].toe;
         double diff = fabs(t - toe);
@@ -78,7 +78,7 @@ int select_channels(channel_t *ch,int *n,const coord_t*u,
     struct cand{int prn;double elev,rho,rdot;int pri;} c[63];
     int m=0;
     double uv[3]={-OMEGA_E*u->xyz[1], OMEGA_E*u->xyz[0], 0.0};
-    for(int prn=1;prn<=63;++prn){
+    for(int prn=1;prn<=prn_max;++prn){
         if(single_prn>0 && prn!=single_prn) continue;
         if(no_geo && is_d2_prn(prn)) continue;
         double sat[3],vel[3];

--- a/bdssim.h
+++ b/bdssim.h
@@ -57,6 +57,7 @@ typedef struct {
     bool     geo_first;        /* 優先可見 GEO 衛星 */
     bool     no_geo;           /* 排除 GEO 衛星 */
     int      single_prn;       /* 僅模擬此 PRN (0 = 全部) */
+    bool     prn37_only;       /* 僅使用 1-37 號衛星 */
 } sim_config_t;
 
 /* ---------- 介面 ---------- */

--- a/channel.c
+++ b/channel.c
@@ -123,7 +123,7 @@ static const uint8_t nh20_bits[20]={
 static void load_ca_once(void)
 {
     if(ca_ready) return;
-    for(int p=1;p<=63;++p)
+    for(int p=1;p<=prn_max;++p)
         for(int i=0;i<CODE_LEN;++i)
             ca_wave[p][i] = prn_code[p][i]?+1:-1;
     ca_ready = 1;

--- a/globals.c
+++ b/globals.c
@@ -21,6 +21,7 @@ double iono_beta[4]  = {0};
 int    utc_bdt_diff  = 4;   /* default UTC->BDT offset */
 
 int simulator_inited = 0;
+int prn_max = 63;
 
 /* ───────────── B1I PRN 產生 ───────────── */
 #define ITER 2047                     /* 先跑滿 2047，再丟掉最後 1 chip */
@@ -82,15 +83,16 @@ static void cb1i_generate(int prn, uint8_t *dst)
 
 static void init_prn_table(void)
 {
-    for (int p = 1; p <= 63; ++p)
+    for (int p = 1; p <= prn_max; ++p)
         cb1i_generate(p, prn_code[p]);
-    puts("[bdssim] PRN 表已產生 (1–63)");
+    printf("[bdssim] PRN 表已產生 (1–%d)\n", prn_max);
 }
 
 /* ───────────── 對外 API ───────────── */
 bool init_simulator(sim_config_t *cfg, double start_bdt)
 {
     if(simulator_inited) return true;
+    prn_max = cfg->prn37_only ? 37 : 63;
     init_prn_table();
     memset(eph, 0, sizeof(eph));
     if(read_rinex_nav(cfg->rinex_file, start_bdt)!=0) return false;

--- a/globals.h
+++ b/globals.h
@@ -18,6 +18,7 @@
 extern uint8_t      prn_code[MAX_SAT][CODE_LEN];
 extern ephemeris_t  eph[MAX_SAT];
 extern int          simulator_inited;
+extern int          prn_max;        /* 上限 PRN 編號 */
 extern double       nav_time_min;
 extern double       nav_time_max;
 extern int          nav_week;       /* ephemeris week reference */

--- a/main.c
+++ b/main.c
@@ -27,6 +27,7 @@ static void usage(const char *p)
     puts("  --geo-first          優先可見 GEO 衛星");
     puts("  --no-geo            排除 GEO 衛星");
     puts("  --prn N             僅模擬指定 PRN");
+    puts("  --prn37             僅使用 1-37 號衛星");
     puts("  --help               顯示本說明\n");
 }
 
@@ -43,6 +44,7 @@ int main(int argc,char *argv[])
     cfg.geo_first  = false;
     cfg.no_geo     = false;
     cfg.single_prn = 0;
+    cfg.prn37_only = false;
     bool llh_given   = false;
 
     /* 處理 "-byte" 舊習慣 */
@@ -76,12 +78,13 @@ int main(int argc,char *argv[])
         {"geo-first",no_argument,       0, 'G'},
         {"no-geo",   no_argument,       0, 'O'},
         {"prn",      required_argument, 0, 'p'},
+        {"prn37",    no_argument,       0, 'B'},
         {"help",     no_argument,       0, 'h'},
         {0,0,0,0}
     };
 
     int c, idx;
-    while((c = getopt_long(argc, argv, "e:t:l:x:y:n:d:g:R:hbGOp:", longopt, &idx)) != -1){
+    while((c = getopt_long(argc, argv, "e:t:l:x:y:n:d:g:R:hbGOp:B", longopt, &idx)) != -1){
         switch(c){
         case 'e':
             strncpy(cfg.rinex_file, optarg, sizeof(cfg.rinex_file)-1);
@@ -138,6 +141,9 @@ int main(int argc,char *argv[])
         case 'p':
             cfg.single_prn = atoi(optarg);
             break;
+        case 'B':
+            cfg.prn37_only = true;
+            break;
         case 'h':
             usage(argv[0]);
             return 0;
@@ -171,8 +177,9 @@ int main(int argc,char *argv[])
         fputs("--llh 超出合理範圍\n", stderr);
         return 1;
     }
-    if(cfg.single_prn<0 || cfg.single_prn>63){
-        fputs("--prn 範圍 1-63\n", stderr);
+    int prn_limit = cfg.prn37_only ? 37 : 63;
+    if(cfg.single_prn<0 || cfg.single_prn>prn_limit){
+        fprintf(stderr,"--prn 範圍 1-%d\n", prn_limit);
         return 1;
     }
 

--- a/navbits.c
+++ b/navbits.c
@@ -4,6 +4,7 @@
 #include <string.h>
 #include "navbits.h"
 #include "bch.h"
+#include "globals.h"
 
 static inline double rad_to_sc(double v){return v/M_PI;}
 
@@ -648,7 +649,7 @@ static uint8_t sf_static[MAX_SAT][4][SF_STREAM_LEN]; /* subframe 2-5 */
 
 void navbits_init(void)
 {
-    for(int prn=1;prn<=63;prn++){
+    for(int prn=1;prn<=prn_max;prn++){
         B1I_D1_Frame frm;
         frame_from_ephemeris(&eph[prn], &frm);
         uint32_t words[10];


### PR DESCRIPTION
## Summary
- add `--prn37` flag that limits simulation to satellites PRNs 1-37
- gate PRN tables and channel selection on new configurable `prn_max`
- document PRN restriction option in README

## Testing
- `make check`
- `./bds-sim --rinex BRDM00DLR_S_20251760000_01D_MN.rnx --start 2025/06/25,00:00:00 --llh 0,0,0 --duration 1 --prn37`


------
https://chatgpt.com/codex/tasks/task_e_688e5fdaa7b08327bb86d994c019d877