### PR TITLE
Fix dynamic mode center frequency

### DIFF
--- a/bdssim.c
+++ b/bdssim.c
@@ -256,6 +256,12 @@ void generate_signal(const sim_config_t *cfg)
                 printf("[ch%02d] rdot %.2f fd %.2fHz\n", ch[i].prn, rdot, ch[i].fd);
             }
         }
+        if (cfg->path_type != 0) {
+            for (int i = 0; i < n_ch; ++i) {
+                ch[i].fd = 0.0;
+                ch[i].fd_dot = 0.0;
+            }
+        }
 
         /* --- STEP_MS 次 1ms 取樣 --- */
         for(int step=0;step<STEP_MS;++step){


### PR DESCRIPTION
## Summary
- clear carrier Doppler for dynamic user paths to keep spectrum centered at 0

## Testing
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_688e84521bd08327abc8f9bec8dc94ef