### PR TITLE
Implement proper B1I dual-channel modulation

### DIFF
--- a/channel.c
+++ b/channel.c
@@ -9,6 +9,7 @@
 #define PI2        6.2831853071795864769
 #define FCARRIER   1561.098e6      /* B1I */
 #define CHIPRATE   2.046e6
+#define INV_SQRT2  0.70710678118654752440
 static double fs = FS_OUTPUT_HZ;           /* default sample rate */
 
 /* default target CN0, overridable via CLI */
@@ -242,12 +243,15 @@ void gen_samples_1ms(channel_t *c,int week,double sow,
     for(int n=0;n<samp_per_ms;++n){
         int chip = (int)code_phase;            /* 0..2045 */
         int16_t ca = ca_wave[c->prn][chip];
-        uint8_t nh = nh20_bits[c->ms_count];
-        int16_t nb = (c->nav_bits[c->bit_ptr]^nh)?-1:+1;
+        int16_t d1 = c->nav_bits[c->bit_ptr] ? -1 : +1;   /* D1 資料 */
+        int16_t nh = nh20_bits[c->ms_count] ? -1 : +1;    /* NH20 pilot */
+        float i_sym = ca * d1 * INV_SQRT2;
+        float q_sym = ca * nh * INV_SQRT2;
         float co,si; fast_sincos(phase,&co,&si);
-        float s = amp*ca*nb;
-        I[n]=(int16_t)lrintf(s*co);
-        Q[n]=(int16_t)lrintf(s*si);
+        float ci = amp * i_sym;
+        float cq = amp * q_sym;
+        I[n] = (int16_t)lrintf(ci*co - cq*si);
+        Q[n] = (int16_t)lrintf(ci*si + cq*co);
 
         phase += PI2*(fd + 0.5*dfd)/fs;
         fd += dfd;
@@ -299,11 +303,14 @@ void gen_samples_1ms_d2(channel_t *c, int week, double sow,
     for(int n=0;n<samp_per_ms;++n){
         int chip = (int)code_phase;
         int16_t ca = ca_wave[c->prn][chip];
-        int16_t nb = c->nav_bits_d2[c->bit_ptr_d2] ? -1:+1;
+        int16_t d2 = c->nav_bits_d2[c->bit_ptr_d2] ? -1 : +1; /* D2 資料 */
+        float i_sym = ca * INV_SQRT2;         /* I 路純 PRN pilot */
+        float q_sym = ca * d2 * INV_SQRT2;
         float co,si; fast_sincos(phase,&co,&si);
-        float s = amp*ca*nb;
-        I[n]=(int16_t)lrintf(s*co);
-        Q[n]=(int16_t)lrintf(s*si);
+        float ci = amp * i_sym;
+        float cq = amp * q_sym;
+        I[n] = (int16_t)lrintf(ci*co - cq*si);
+        Q[n] = (int16_t)lrintf(ci*si + cq*co);
 
         phase += PI2*(fd + 0.5*dfd)/fs;
         fd += dfd;
@@ -312,9 +319,8 @@ void gen_samples_1ms_d2(channel_t *c, int week, double sow,
         code_phase += (code_rate + 0.5*dcode_rate)/fs;
         code_rate += dcode_rate;
         amp += damp;
-        if(code_phase>=CODE_LEN){
+        if(code_phase>=CODE_LEN)
             code_phase-=CODE_LEN;
-        }
     }
     c->fd = fd;
     c->code_rate = code_rate;

--- a/tests/test_d2_cycles.c
+++ b/tests/test_d2_cycles.c
@@ -16,29 +16,31 @@ int main(void)
         return 1;
     }
 
-    int prn = 3; /* GEO uses D2 without NH */
+    int prn = 3; /* GEO uses D2 on Q, pure PRN pilot on I */
     channel_t ch;
     channel_reset(&ch, prn, nav_week, 0.0);
     ch.carr_phase = 0.0;
-    ch.code_phase = 0.1; /* avoid boundary ambiguity */
+    ch.code_phase = 0.0; /* start at chip 0 */
     update_channel_dynamics(&ch, 2.0e7, 0.0, 90.0, 1.0, cfg.target_cn0, 1, 1.0);
     channel_set_fs(FS_OUTPUT_HZ);
 
     int samp_per_ms = (int)(FS_OUTPUT_HZ/1000.0 + 0.5);
     int16_t I[samp_per_ms], Q[samp_per_ms];
 
-    /* generate 2 ms and verify D2 bit spans two PRN cycles */
-    for(int i=0;i<2;i++){
-        gen_samples_1ms_d2(&ch, nav_week, i*0.001, samp_per_ms, I, Q);
-        if(i==0){
-            assert(ch.ms_count_d2 == 1);
-            assert(ch.bit_ptr_d2 == 0);
-        } else {
-            assert(ch.ms_count_d2 == 0);
-            assert(ch.bit_ptr_d2 == 1);
-        }
-        assert(fabs(ch.code_phase - 0.1) < 1e-6);
-    }
+    /* first ms: verify I pilot and Q carries D2 */
+    gen_samples_1ms_d2(&ch, nav_week, 0.0, samp_per_ms, I, Q);
+    int ca = prn_code[prn][0] ? +1 : -1;
+    int d2 = ch.nav_bits_d2[0] ? -1 : +1;
+    assert(I[0] * ca > 0);
+    assert(Q[0] * (ca*d2) > 0);
+    assert(ch.ms_count_d2 == 1);
+    assert(ch.bit_ptr_d2 == 0);
+
+    /* next ms completes the 2 ms D2 bit */
+    gen_samples_1ms_d2(&ch, nav_week, 0.001, samp_per_ms, I, Q);
+    assert(ch.ms_count_d2 == 0);
+    assert(ch.bit_ptr_d2 == 1);
+    assert(fabs(ch.code_phase - 0.0) < 1e-6);
 
     cleanup_simulator();
     return 0;

--- a/tests/test_nh_prn.c
+++ b/tests/test_nh_prn.c
@@ -6,6 +6,10 @@
 #include "../channel.h"
 #include "../globals.h"
 
+static const int nh20_bits[20]={
+    0,0,0,0,0,1,0,0,1,1,0,1,0,1,0,0,1,1,1,0
+};
+
 int main(void)
 {
     sim_config_t cfg = {0};
@@ -16,19 +20,27 @@ int main(void)
         return 1;
     }
 
-    int prn = 8; /* MEO/IGSO uses D1 with NH code */
+    int prn = 8; /* MEO/IGSO uses D1 with NH pilot */
     channel_t ch;
     channel_reset(&ch, prn, nav_week, 0.0);
     ch.carr_phase = 0.0;
-    ch.code_phase = 0.1; /* avoid boundary ambiguity */
+    ch.code_phase = 0.0; /* start at chip 0 */
     update_channel_dynamics(&ch, 2.0e7, 0.0, 90.0, 1.0, cfg.target_cn0, 1, 1.0);
     channel_set_fs(FS_OUTPUT_HZ);
 
     int samp_per_ms = (int)(FS_OUTPUT_HZ/1000.0 + 0.5);
     int16_t I[samp_per_ms], Q[samp_per_ms];
 
-    /* generate 20 ms and verify NH/PRN relationship */
-    for(int i=0;i<20;i++){
+    /* first ms: verify I carries D1 and Q carries NH */
+    gen_samples_1ms(&ch, nav_week, 0.0, samp_per_ms, I, Q);
+    int ca = prn_code[prn][0] ? +1 : -1;
+    int d1 = ch.nav_bits[0] ? -1 : +1;
+    int nh = nh20_bits[0] ? -1 : +1;
+    assert(I[0] * (ca*d1) > 0);
+    assert(Q[0] * (ca*nh) > 0);
+
+    /* remaining 19 ms: check NH cycle and bit pointer */
+    for(int i=1;i<20;i++){
         gen_samples_1ms(&ch, nav_week, i*0.001, samp_per_ms, I, Q);
         if(i<19){
             assert(ch.ms_count == (i+1));
@@ -37,7 +49,7 @@ int main(void)
             assert(ch.ms_count == 0);
             assert(ch.bit_ptr == 1);
         }
-        assert(fabs(ch.code_phase - 0.1) < 1e-6);
+        assert(fabs(ch.code_phase - 0.0) < 1e-6);
     }
 
     cleanup_simulator();


### PR DESCRIPTION
## Summary
- Correctly model BeiDou B1I as dual-channel QPSK
- Verify I/Q branch contents for D1 and D2 satellites

## Testing
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_688f472f39b483278df53a3b8e53ae27