### PR TITLE
Fix inconsistent PRN numbers between config and dynamics

### DIFF
--- a/bdssim.c
+++ b/bdssim.c
@@ -13,7 +13,6 @@
 #include "timeconv.h"
 #include "path.h"
 #include "globals.h"     /* nav_week */
-#define OMEGA_E   7.2921150e-5
 #define FSAMP_DEF FS_OUTPUT_HZ    /* default 6.144 MHz for 16-bit I/Q output */
 #define FSAMP_BYTE 25.0e6    /* 25 MHz when --byte is used */
 #define FCARRIER   1561.098e6      /* B1I carrier */
@@ -45,30 +44,6 @@ static void check_ephemeris_age(int week,double sow)
     }
     if(warn)
         fputs("建議使用接近星曆 toe 的起始時間以避免 tk 錯誤\n", stderr);
-}
-
-/* ---- Rotate fixed LLH with Earth rotation ----- */
-static void static_user_at(int week,double sow,const coord_t*ref,
-                           coord_t*out,double vel[3])
-{
-    double lat=ref->llh[0]*(M_PI/180.0);
-    double lon0=ref->llh[1]*(M_PI/180.0);
-    double h=ref->llh[2];
-    double sinp=sin(lat); double cosp=cos(lat);
-    double N=WGS_A/sqrt(1.0-WGS_E2*sinp*sinp);
-    double t=(week-nav_week)*604800.0 + sow;
-    double lon=lon0 + OMEGA_E*t;
-    double cosL=cos(lon), sinL=sin(lon);
-    out->xyz[0]=(N+h)*cosp*cosL;
-    out->xyz[1]=(N+h)*cosp*sinL;
-    out->xyz[2]=(N*(1.0-WGS_E2)+h)*sinp;
-    out->llh[0]=ref->llh[0]; out->llh[1]=ref->llh[1]; out->llh[2]=ref->llh[2];
-    out->week=week; out->sow=sow;
-    if(vel){
-        vel[0]=-OMEGA_E*out->xyz[1];
-        vel[1]= OMEGA_E*out->xyz[0];
-        vel[2]=0.0;
-    }
 }
 
 /*----------------------------------------------------*/

--- a/coord.c
+++ b/coord.c
@@ -82,4 +82,31 @@ void ecef_to_eci(const double ecef[3],int week,double sow,double eci[3])
     eci[2] = ecef[2];
 }
 
+/* Rotate fixed LLH with Earth rotation ------------------------------- */
+void static_user_at(int week,double sow,const coord_t *ref,
+                    coord_t *out,double vel[3])
+{
+    double lat = ref->llh[0]*(M_PI/180.0);
+    double lon0= ref->llh[1]*(M_PI/180.0);
+    double h   = ref->llh[2];
+    double sinp= sin(lat); double cosp=cos(lat);
+    double N   = WGS_A/sqrt(1.0-WGS_E2*sinp*sinp);
+    double t   = (week-nav_week)*604800.0 + sow;
+    double lon = lon0 + OMEGA_E*t;
+    double cosL= cos(lon), sinL= sin(lon);
+    out->xyz[0]=(N+h)*cosp*cosL;
+    out->xyz[1]=(N+h)*cosp*sinL;
+    out->xyz[2]=(N*(1.0-WGS_E2)+h)*sinp;
+    out->llh[0]=ref->llh[0];
+    out->llh[1]=ref->llh[1];
+    out->llh[2]=ref->llh[2];
+    out->week=week;
+    out->sow=sow;
+    if(vel){
+        vel[0]=-OMEGA_E*out->xyz[1];
+        vel[1]= OMEGA_E*out->xyz[0];
+        vel[2]=0.0;
+    }
+}
+
 

--- a/coord.h
+++ b/coord.h
@@ -20,6 +20,7 @@ void   xyz2llh(const double xyz[3], coord_t *c);
 void   ecef2enu(const coord_t *usr, const double sat_xyz[3], double enu[3]);
 double enu_elevation_deg(const double enu[3]);
 void   ecef_to_eci(const double ecef[3],int week,double sow,double eci[3]);
+void   static_user_at(int week,double sow,const coord_t *ref,coord_t *out,double vel[3]);
 
 #endif
 

--- a/main.c
+++ b/main.c
@@ -9,6 +9,7 @@
 #include "globals.h"
 #include "path.h"
 #include "channel.h"        /* g_target_cn0 */
+#include "coord.h"
 
 /* ───────────────────────────── */
 static void usage(const char *p)
@@ -223,6 +224,9 @@ int main(int argc,char *argv[])
     }
     usr.week = start_week;
     usr.sow  = start_sow;
+
+    coord_t ref_llh = usr;
+    static_user_at(usr.week, usr.sow, &ref_llh, &usr, NULL);
 
     channel_t ch[MAX_CH];
     int n_ch;


### PR DESCRIPTION
## Summary
- Export `static_user_at` from the coordinate module and use it before channel selection so that startup and runtime use the same user position.
- Rotate the user position in `main.c` prior to selecting satellites, ensuring PRN lists printed at startup match those used for Doppler calculations.

## Testing
- `make`
- `make check`
- `./bds-sim --rinex BRDM00DLR_S_20251760000_01D_MN.rnx --start 2025/06/25,00:00:00 --duration 1 --gain 1.0 --llh 24.0,121.0,0.0`


------
https://chatgpt.com/codex/tasks/task_e_688f9c1d167083279919fb05f5787a05