### PR TITLE
Add MEO-only simulation option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,4 +17,5 @@
 * Orbit propagation now uses the unified GPS/BDS RAAN
   expression `Ω(t)=Ω₀+(Ω̇−Ωₑ)·tk−Ωₑ·Toe` for all BeiDou
   satellites
+* Added `--meo-only` flag to simulate only MEO satellites
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ The legacy option `-byte` is still recognised as an alias for `--byte`.
 - IGSO/MEO PRN → D1 (50 bps, 有 NH 二次碼)
 - `--geo-first` 在挑選模擬衛星時會優先加入可見的 GEO 衛星
 - `--no-geo` 排除所有 GEO 衛星
+- `--meo-only` 僅模擬 MEO 衛星
 - `--prn`  可只輸出指定 PRN
 - `--prn37`  僅使用 1-37 號衛星
 

--- a/bdssim.c
+++ b/bdssim.c
@@ -48,13 +48,15 @@ static void check_ephemeris_age(int week,double sow)
 
 /*----------------------------------------------------*/
 int select_channels(channel_t *ch,int *n,const coord_t*u,
-                    bool geo_first,int single_prn,bool no_geo)
+                    bool geo_first,int single_prn,bool no_geo,
+                    bool meo_only)
 {
     struct cand{int prn;double elev,rho,rdot;int pri;} c[63];
     int m=0;
     for(int prn=1;prn<=prn_max;++prn){
         if(single_prn>0 && prn!=single_prn) continue;
         if(no_geo && is_d2_prn(prn)) continue;
+        if(meo_only && !is_meo_prn(prn)) continue;
         double sat[3],vel[3];
         calc_sat_position_velocity(prn,u->week,u->sow,sat,vel);
         double enu[3]; ecef2enu(u,sat,enu);
@@ -157,7 +159,7 @@ void generate_signal(const sim_config_t *cfg)
     channel_t ch[MAX_CH];
     int n_ch;
     select_channels(ch,&n_ch,&usr,cfg->geo_first,
-                    cfg->single_prn,cfg->no_geo);
+                    cfg->single_prn,cfg->no_geo,cfg->meo_only);
 
     double fs = cfg->byte_output ? FSAMP_BYTE : FSAMP_DEF;
     int samp_per_ms = (int)(fs/1000.0 + 0.5);

--- a/bdssim.h
+++ b/bdssim.h
@@ -56,6 +56,7 @@ typedef struct {
     bool     byte_output;      /* 以 8-bit 檔輸出 */
     bool     geo_first;        /* 優先可見 GEO 衛星 */
     bool     no_geo;           /* 排除 GEO 衛星 */
+    bool     meo_only;         /* 只模擬 MEO 衛星 */
     int      single_prn;       /* 僅模擬此 PRN (0 = 全部) */
     bool     prn37_only;       /* 僅使用 1-37 號衛星 */
 } sim_config_t;
@@ -66,5 +67,6 @@ void  generate_signal(const sim_config_t *cfg);   /* ← 加上 const */
 void  cleanup_simulator(void);
 /* 讓 main 可以先做一次 select_channels() 取得 PRN 清單 */
 int  select_channels(channel_t *ch, int *n_ch, const coord_t *usr,
-                     bool geo_first, int single_prn, bool no_geo);
+                     bool geo_first, int single_prn, bool no_geo,
+                     bool meo_only);
 #endif

--- a/main.c
+++ b/main.c
@@ -27,6 +27,7 @@ static void usage(const char *p)
     puts("  --byte               輸出 I-only 之 8-bit 檔");
     puts("  --geo-first          優先可見 GEO 衛星");
     puts("  --no-geo            排除 GEO 衛星");
+    puts("  --meo-only          僅模擬 MEO 衛星");
     puts("  --prn N             僅模擬指定 PRN");
     puts("  --prn37             僅使用 1-37 號衛星");
     puts("  --help               顯示本說明\n");
@@ -44,6 +45,7 @@ int main(int argc,char *argv[])
     cfg.byte_output = false;
     cfg.geo_first  = false;
     cfg.no_geo     = false;
+    cfg.meo_only   = false;
     cfg.single_prn = 0;
     cfg.prn37_only = false;
     bool llh_given   = false;
@@ -78,6 +80,7 @@ int main(int argc,char *argv[])
         {"byte",     no_argument,       0, 'b'},
         {"geo-first",no_argument,       0, 'G'},
         {"no-geo",   no_argument,       0, 'O'},
+        {"meo-only", no_argument,       0, 'M'},
         {"prn",      required_argument, 0, 'p'},
         {"prn37",    no_argument,       0, 'B'},
         {"help",     no_argument,       0, 'h'},
@@ -85,7 +88,7 @@ int main(int argc,char *argv[])
     };
 
     int c, idx;
-    while((c = getopt_long(argc, argv, "e:t:l:x:y:n:d:g:R:hbGOp:B", longopt, &idx)) != -1){
+    while((c = getopt_long(argc, argv, "e:t:l:x:y:n:d:g:R:hbGOp:BM", longopt, &idx)) != -1){
         switch(c){
         case 'e':
             strncpy(cfg.rinex_file, optarg, sizeof(cfg.rinex_file)-1);
@@ -138,6 +141,9 @@ int main(int argc,char *argv[])
             break;
         case 'O':
             cfg.no_geo = true;
+            break;
+        case 'M':
+            cfg.meo_only = true;
             break;
         case 'p':
             cfg.single_prn = atoi(optarg);
@@ -230,7 +236,8 @@ int main(int argc,char *argv[])
 
     channel_t ch[MAX_CH];
     int n_ch;
-    select_channels(ch,&n_ch,&usr,cfg.geo_first,cfg.single_prn,cfg.no_geo);
+    select_channels(ch,&n_ch,&usr,cfg.geo_first,cfg.single_prn,
+                    cfg.no_geo,cfg.meo_only);
 
     /* 印出確認訊息 (簡潔模式) */
     printf("[cfg] UTC %s  BDT W%d %.3f\n",


### PR DESCRIPTION
## Summary
- allow selecting only MEO satellites with new `--meo-only` flag
- document MEO-only mode in README and changelog

## Testing
- `make check`
- `make bds-sim`


------
https://chatgpt.com/codex/tasks/task_e_688fa5e7d1d08327b3fe1871226aa36f