### PR TITLE
Add D1 constant-bit mode and smoother dynamics

### DIFF
--- a/bdssim.c
+++ b/bdssim.c
@@ -153,6 +153,7 @@ void generate_signal(const sim_config_t *cfg)
     static_user_at(usr.week,usr.sow,&ref_llh,&usr,NULL);
 
     navbits_init();
+    g_force_d1_constant_bits = cfg->force_d1_constant_bits;
 
     /* 檢查 start 時間是否與星曆 toe 接近 */
     check_ephemeris_age(usr.week, usr.sow);
@@ -194,29 +195,36 @@ void generate_signal(const sim_config_t *cfg)
     double start_bdt = usr.week*604800.0 + usr.sow;
     for(uint64_t ms=0; ms<total_ms; ms+=STEP_MS)
     {
+        const double GEOM_OFF = 0.003;   /* 3 ms offset to avoid bit boundaries */
         double t_abs = start_bdt + ms*0.001;
         int week = (int)(t_abs/604800.0);
         double sow = t_abs - week*604800.0;
-
         double dt = STEP_MS * 0.001;
+        double t_geom = t_abs + GEOM_OFF;
+        int week_g = (int)(t_geom/604800.0);
+        double sow_g = t_geom - week_g*604800.0;
+        double t_geom_next = t_geom + dt;
+        int week_g2 = (int)(t_geom_next/604800.0);
+        double sow_g2 = t_geom_next - week_g2*604800.0;
         double uvel[3], uvel_next[3];
         coord_t usr_next={0};
         if(cfg->path_type==0){
-            usr.week = week;
-            usr.sow  = sow;
+            usr.week = week_g;
+            usr.sow  = sow_g;
             usr_next = usr;
-            usr_next.sow = sow + dt;
+            usr_next.week = week_g2;
+            usr_next.sow  = sow_g2;
             uvel[0]=uvel[1]=uvel[2]=0.0;
             uvel_next[0]=uvel_next[1]=uvel_next[2]=0.0;
             update_channels_path(cfg,ch,n_ch,&usr,uvel,&usr_next,uvel_next,
                                  cfg->gain,g_target_cn0,STEP_MS);
         } else if(cfg->path_type==1){
             coord_t u0,u1,u2;
-            interpolate_path(&path, ms/1000.0, &u0);
-            interpolate_path(&path, (ms+STEP_MS)/1000.0, &u1);
-            interpolate_path(&path, (ms+2*STEP_MS)/1000.0, &u2);
-            xyz2llh(u0.xyz,&usr); usr.week=week; usr.sow=sow;
-            xyz2llh(u1.xyz,&usr_next);
+            interpolate_path(&path, ms/1000.0 + GEOM_OFF, &u0);
+            interpolate_path(&path, (ms+STEP_MS)/1000.0 + GEOM_OFF, &u1);
+            interpolate_path(&path, (ms+2*STEP_MS)/1000.0 + GEOM_OFF, &u2);
+            xyz2llh(u0.xyz,&usr); usr.week=week_g; usr.sow=sow_g;
+            xyz2llh(u1.xyz,&usr_next); usr_next.week=week_g2; usr_next.sow=sow_g2;
             xyz2llh(u2.xyz,&u2);
             uvel[0]=(u1.xyz[0]-u0.xyz[0])/dt;
             uvel[1]=(u1.xyz[1]-u0.xyz[1])/dt;
@@ -228,16 +236,20 @@ void generate_signal(const sim_config_t *cfg)
                                  cfg->gain,g_target_cn0,STEP_MS);
         } else {
             double llh0[3], llh1[3], llh2[3];
-            interpolate_path_llh(&path, ms/1000.0, llh0);
-            interpolate_path_llh(&path, (ms+STEP_MS)/1000.0, llh1);
-            interpolate_path_llh(&path, (ms+2*STEP_MS)/1000.0, llh2);
+            interpolate_path_llh(&path, ms/1000.0 + GEOM_OFF, llh0);
+            interpolate_path_llh(&path, (ms+STEP_MS)/1000.0 + GEOM_OFF, llh1);
+            interpolate_path_llh(&path, (ms+2*STEP_MS)/1000.0 + GEOM_OFF, llh2);
             coord_t ref0={0}, ref1={0}, ref2={0};
             ref0.llh[0]=llh0[0]; ref0.llh[1]=llh0[1]; ref0.llh[2]=llh0[2];
             ref1.llh[0]=llh1[0]; ref1.llh[1]=llh1[1]; ref1.llh[2]=llh1[2];
             ref2.llh[0]=llh2[0]; ref2.llh[1]=llh2[1]; ref2.llh[2]=llh2[2];
-            static_user_at(week,sow,&ref0,&usr,NULL);
-            static_user_at(week,sow+dt,&ref1,&usr_next,NULL);
-            coord_t usr2; static_user_at(week,sow+2*dt,&ref2,&usr2,NULL);
+            static_user_at(week_g,sow_g,&ref0,&usr,NULL);
+            static_user_at(week_g2,sow_g2,&ref1,&usr_next,NULL);
+            double t_geom2 = t_geom_next + dt;
+            int week_g3 = (int)(t_geom2/604800.0);
+            double sow_g3 = t_geom2 - week_g3*604800.0;
+            coord_t usr2;
+            static_user_at(week_g3,sow_g3,&ref2,&usr2,NULL);
             uvel[0]=(usr_next.xyz[0]-usr.xyz[0])/dt;
             uvel[1]=(usr_next.xyz[1]-usr.xyz[1])/dt;
             uvel[2]=(usr_next.xyz[2]-usr.xyz[2])/dt;

--- a/bdssim.h
+++ b/bdssim.h
@@ -63,6 +63,7 @@ typedef struct {
     /* ---- Simulation toggles ---- */
     int   enable_geo_d2;       /* 0=禁用 GEO/D2（預設）; 1=啟用 GEO/D2 */
     int   zero_doppler_geo;    /* 1=將 GEO r_dot 視為 0（僅當 enable_geo_d2=1 時生效）*/
+    int   force_d1_constant_bits; /* 0=送真資料; 1=所有 D1 資料位固定 +1 */
 } sim_config_t;
 
 /* ---------- 介面 ---------- */

--- a/channel.c
+++ b/channel.c
@@ -13,6 +13,7 @@ static double fs = FS_OUTPUT_HZ;           /* default sample rate */
 
 /* default target CN0, overridable via CLI */
 double g_target_cn0 = 42.0;
+int    g_force_d1_constant_bits = 0;
 
 /* (舊的接收天線圖與 multipath 模型已移除) */
 
@@ -222,11 +223,6 @@ void gen_samples_1ms(channel_t *c,int week,double sow,
                      int samp_per_ms,int16_t*I,int16_t*Q)
 {
     (void)sow;
-    if(c->bit_ptr==0 && c->ms_count==0){
-        /* 一律使用固定錨點 + 6.0 * index，杜絕邊界抖動 */
-        double t0 = c->d1_sf_t0 + 6.0 * c->d1_sf_index;
-        get_subframe_bits(c->prn,c->sf_id,week,t0,6.0,c->nav_bits);
-    }
 
     double fd = c->fd;
     double code_rate = c->code_rate;
@@ -241,7 +237,11 @@ void gen_samples_1ms(channel_t *c,int week,double sow,
         int chip = (int)code_phase;            /* 0..2045 */
         int16_t ca = ca_wave[c->prn][chip];
         uint8_t nh = nh20_bits[c->ms_count];
-        int16_t nb = (c->nav_bits[c->bit_ptr]^nh)?-1:+1;
+        int16_t nh_sign = nh ? -1 : +1;
+        int16_t data_bit = g_force_d1_constant_bits
+                           ? +1
+                           : (c->nav_bits[c->bit_ptr] ? -1 : +1);
+        int16_t nb = data_bit * nh_sign;
         float co,si; fast_sincos(phase,&co,&si);
         float s = amp*ca*nb;
         I[n]=(int16_t)lrintf(s*co);
@@ -262,6 +262,8 @@ void gen_samples_1ms(channel_t *c,int week,double sow,
                     c->bit_ptr=0;
                     c->sf_id=c->sf_id%5+1;      /* 1..5 */
                     c->d1_sf_index=(c->d1_sf_index+1)%5;
+                    double t0 = c->d1_sf_t0 + 6.0 * c->d1_sf_index;
+                    get_subframe_bits(c->prn,c->sf_id,week,t0,6.0,c->nav_bits);
                 }
             }
         }

--- a/channel.h
+++ b/channel.h
@@ -55,6 +55,7 @@ double predict_next_amp(const channel_t *c,double rho_next,double elev_deg_next,
 
 /* Global target CN0 (dB-Hz) */
 extern double g_target_cn0;
+extern int    g_force_d1_constant_bits;  /* 1=所有 D1 資料位固定 +1；0=送真資料 */
 
 /* === 修正：用指標而非 array declarator === */
 void get_subframe_bits(int prn, int sf_id, int week, double sow,


### PR DESCRIPTION
## Summary
- add `force_d1_constant_bits` flag to optionally fix D1 bits to +1
- update channel generation to honor the flag and tighten bit/NH boundary handling
- offset geometry/dynamics updates by 3 ms to avoid boundary alignment

## Testing
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_6891cff32bd4832793495be830b6782e