### PR TITLE
Calibrate amplitude and refine dynamics timing

### DIFF
--- a/bdssim.c
+++ b/bdssim.c
@@ -17,6 +17,7 @@
 #define FSAMP_BYTE 25.0e6    /* 25 MHz when --byte is used */
 #define FCARRIER   1561.098e6      /* B1I carrier */
 #define CHIPRATE   2.046e6
+#define TARGET_RMS 12000.0          /* clipping guard RMS threshold */
 
 /* ========= 振幅計算與 int16 飽和保護 ========= */
 static inline int16_t saturate_int16(double x)
@@ -99,7 +100,7 @@ static void update_channels_path(const sim_config_t *cfg, channel_t *ch,int n,
         double rdot=(dx*(vel[0]-uvel[0]) + dy*(vel[1]-uvel[1]) + dz*(vel[2]-uvel[2]))/rho;
         if(is_d2_prn(prn) && (cfg->no_geo || cfg->zero_doppler_geo))
             rdot = 0.0;
-        update_channel_dynamics(&ch[i],rho,rdot,el,gain,target_cn0,n,step_ms);
+        update_channel_dynamics(&ch[i],rho,rdot,el,gain,target_cn0,step_ms);
         if(el < 5.0) ch[i].amp = 0.0;     /* below horizon → mute */
 
         /* predict next dynamics using next position/velocity */
@@ -119,7 +120,7 @@ static void update_channels_path(const sim_config_t *cfg, channel_t *ch,int n,
         double el2 = enu_elevation_deg(enu2);
         double fd2 = -FCARRIER*rdot2/299792458.0;
         double cr2 = CHIPRATE*(1.0 - rdot2/299792458.0);
-        double A2 = predict_next_amp(&ch[i], rho2, el2, gain, target_cn0, n, step_ms);
+        double A2 = predict_next_amp(&ch[i], rho2, el2, gain, target_cn0, step_ms);
         if(el2 < 5.0) A2 = 0.0;
         ch[i].fd_dot = (fd2 - ch[i].fd) / dt;
         ch[i].code_rate_dot = (cr2 - ch[i].code_rate) / dt;
@@ -267,8 +268,20 @@ void generate_signal(const sim_config_t *cfg)
         }
 
         /* --- STEP_MS 次 1ms 取樣 --- */
-        for(int step=0;step<STEP_MS;++step){
-            memset(accI,0,sizeof(accI)); memset(accQ,0,sizeof(accQ));
+        for(int step=0; step<STEP_MS; ++step){
+            /* --- 根據當前振幅估計全域縮放避免飽和 --- */
+            double sum_power = 0.0;
+            for(int c=0; c<n_ch; ++c){
+                double a = ch[c].amp;
+                sum_power += 0.5 * a * a;
+            }
+            double global_scale = 1.0;
+            double total_rms = sqrt(sum_power);
+            if(total_rms > TARGET_RMS)
+                global_scale = TARGET_RMS / total_rms;
+
+            memset(accI,0,sizeof(accI));
+            memset(accQ,0,sizeof(accQ));
 
             /* 併行各通道 */
             #pragma omp parallel for
@@ -288,21 +301,21 @@ void generate_signal(const sim_config_t *cfg)
             int16_t iq[2*samp_per_ms];
             int8_t  i8[samp_per_ms];            /* byte output holds I only */
             for(int k=0;k<samp_per_ms;++k){
-                int32_t i=accI[k];
-                int32_t q=accQ[k];
+                double di = global_scale * accI[k];
+                double dq = global_scale * accQ[k];
                 if(fp){
-                    if(i>32760 || i<-32760) clip_cnt++;
-                    if(q>32760 || q<-32760) clip_cnt++;
+                    if(di>32760.0 || di<-32760.0) clip_cnt++;
+                    if(dq>32760.0 || dq<-32760.0) clip_cnt++;
                     tot_cnt += 2;
-                    iq[2*k]   = saturate_int16((double)i);
-                    iq[2*k+1] = saturate_int16((double)q);
+                    iq[2*k]   = saturate_int16(di);
+                    iq[2*k+1] = saturate_int16(dq);
                     sumI  += iq[2*k];
                     sumQ  += iq[2*k+1];
                     sumI2 += (double)iq[2*k]*iq[2*k];
                     sumQ2 += (double)iq[2*k+1]*iq[2*k+1];
                 } else {
-                    if (i>127) i=127; else if (i<-128) i=-128;
-                    i8[k] = (int8_t)i;
+                    if (di > 127.0) di = 127.0; else if (di < -128.0) di = -128.0;
+                    i8[k] = (int8_t)llround(di);
                     sumI  += i8[k];
                     sumI2 += (double)i8[k]*i8[k];
                 }

--- a/channel.c
+++ b/channel.c
@@ -95,16 +95,15 @@ static void init_ant_pat(void){
 }
 
 static inline double amp_from_geom(double rho,double elev_deg,double gain,
-                                   double cn0_dBHz,int n_visible)
+                                   double cn0_dBHz)
 {
     double base = pow(10.0,(cn0_dBHz-45.0)/20.0) * 16384.0;
     double path_loss = 20200000.0 / rho; /* gps-sdr-sim constant */
     int ibs = (int)((90.0 - elev_deg)/5.0);
     if(ibs < 0) ibs = 0; else if(ibs > 36) ibs = 36;
     double ant = ant_pat[ibs];
-    if (n_visible < 1) n_visible = 1;
     double A = base * path_loss * ant * gain;
-    return (A / sqrt((double)n_visible)) * HEADROOM_RATIO;
+    return A * HEADROOM_RATIO;
 }
 
 static inline double orbit_gain_amp(int prn)
@@ -130,10 +129,10 @@ static inline double smooth_amp(double A_prev, double A_new, double dt_ms)
 
 /* 預測下一步的平滑振幅 */
 double predict_next_amp(const channel_t *c,double rho_next,double elev_deg_next,
-                        double gain,double target_cn0,int n_visible,double dt_ms)
+                        double gain,double target_cn0,double dt_ms)
 {
     double A_new = amp_from_geom(rho_next,elev_deg_next,gain,
-                                 target_cn0,n_visible);
+                                 target_cn0);
     A_new *= orbit_gain_amp(c->prn);
     return smooth_amp(c->amp, A_new, dt_ms);
 }
@@ -201,10 +200,9 @@ void channel_reset(channel_t *c,int prn,int week,double sow){
 }
 /* 幾何→計算振幅 / 初始多普勒 */
 void update_channel_dynamics(channel_t *c,double rho,double rdot,double elev_deg,
-                             double gain,double target_cn0,int n_visible,
-                             double dt_ms)
+                             double gain,double target_cn0,double dt_ms)
 {
-    double A_new = amp_from_geom(rho,elev_deg,gain,target_cn0,n_visible);
+    double A_new = amp_from_geom(rho,elev_deg,gain,target_cn0);
     A_new *= orbit_gain_amp(c->prn);
     c->amp = smooth_amp(c->amp, A_new, dt_ms);
     c->amp_dot = 0.0;

--- a/channel.h
+++ b/channel.h
@@ -38,8 +38,7 @@ void channel_reset(channel_t *, int prn, int week, double sow);
 void channel_set_time(channel_t *, int week, double sow);
 void update_channel_dynamics(channel_t *, double rho, double rdot,
                              double elev_deg, double gain,
-                             double target_cn0, int n_visible,
-                             double dt_ms);
+                             double target_cn0, double dt_ms);
 void channel_set_fs(double sample_rate);
 void gen_samples_1ms(channel_t *, int week, double sow,
                      int samp_per_ms, int16_t *I, int16_t *Q);
@@ -51,7 +50,7 @@ int  is_d2_prn(int prn);
 int  is_igso_prn(int prn);
 int  is_meo_prn(int prn);
 double predict_next_amp(const channel_t *c,double rho_next,double elev_deg_next,
-                        double gain,double target_cn0,int n_visible,double dt_ms);
+                        double gain,double target_cn0,double dt_ms);
 
 /* Global target CN0 (dB-Hz) */
 extern double g_target_cn0;

--- a/main.c
+++ b/main.c
@@ -39,7 +39,7 @@ int main(int argc,char *argv[])
     sim_config_t cfg = {0};
     cfg.gain        = 1.0;
     cfg.target_cn0  = 45.0;            /* dB-Hz */
-    cfg.step_ms     = 100;
+    cfg.step_ms     = 10;
     cfg.duration    = 300;                /* 預設 300 秒 */
     cfg.seed        = 1;
     cfg.byte_output = false;

--- a/tests/test_nh_prn.c
+++ b/tests/test_nh_prn.c
@@ -26,7 +26,7 @@ int main(void)
     channel_reset(&ch, prn, nav_week, 0.0);
     ch.carr_phase = 0.0;
     ch.code_phase = 0.1; /* avoid boundary ambiguity */
-    update_channel_dynamics(&ch, 2.0e7, 0.0, 90.0, 1.0, cfg.target_cn0, 1, 1.0);
+    update_channel_dynamics(&ch, 2.0e7, 0.0, 90.0, 1.0, cfg.target_cn0, 1.0);
     channel_set_fs(FS_OUTPUT_HZ);
 
     int samp_per_ms = (int)(FS_OUTPUT_HZ/1000.0 + 0.5);


### PR DESCRIPTION
## Summary
- Hold per-satellite amplitude constant and remove star-count attenuation
- Apply global RMS-based scaling to prevent clipping only when needed
- Default dynamic update period reduced to 10 ms for smoother tracking

## Testing
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_6891dd3925f483278f8d666e8de45327