### PR TITLE
Skip unhealthy satellites and force SatH1=0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,4 +18,6 @@
   expression `Ω(t)=Ω₀+(Ω̇−Ωₑ)·tk−Ωₑ·Toe` for all BeiDou
   satellites
 * Added `--meo-only` flag to simulate only MEO satellites
+* Skip satellites marked unhealthy in ephemeris and
+  always emit `SatH1=0` in navigation data
 

--- a/navbits.c
+++ b/navbits.c
@@ -34,7 +34,7 @@ static void frame_from_ephemeris(const ephemeris_t *e, B1I_D1_Frame *f)
     f->toc      = (uint32_t)(e->toc / 8);
     f->aodc     = e->aodc & 0x1F;
     f->urai     = e->ura & 0xF;
-    f->satH1    = e->health & 0x1;
+    f->satH1    = 0;                  /* ignore ephemeris health */
 
     /* TGD values: 0.1 ns resolution (ICD 5.2.4.10) */
     f->tgd1     = (int32_t)llround(e->tgd1 / 1e-10);

--- a/rinex.c
+++ b/rinex.c
@@ -134,6 +134,8 @@ int read_rinex_nav(const char *fname, double start_bdt)
         /* line 7: SV accuracy/health and TGD1/2 */
         tmp.ura     = ifld(r[5], 0, INDN) & 0xF;
         tmp.health  = ifld(r[5], 1, INDN) & 0x1;
+        if (tmp.health == 1)                /* SatH1=1 ⇒ skip satellite */
+            continue;
         tmp.tgd1    = fld(r[5], 2, INDN);
         tmp.tgd2    = fld(r[5], 3, INDN);
 


### PR DESCRIPTION
## Summary
- Ignore ephemeris entries where SatH1 indicates an unhealthy satellite
- Always write SatH1=0 when assembling BeiDou navigation messages
- Document skipping of unhealthy satellites

## Testing
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_68920327d39c8327a640077640b1685d