### PR TITLE
Refine pseudorange with clock and Earth rotation corrections

### DIFF
--- a/bdssim.c
+++ b/bdssim.c
@@ -17,6 +17,8 @@
 #define FSAMP_BYTE 25.0e6    /* 25 MHz when --byte is used */
 #define FCARRIER   1561.098e6      /* B1I carrier */
 #define CHIPRATE   2.046e6
+#define CLIGHT     299792458.0
+#define OMEGA_E    7.2921150e-5
 
 /* ========= 振幅計算與 int16 飽和保護 ========= */
 static inline int16_t saturate_int16(double x)
@@ -46,6 +48,46 @@ static void check_ephemeris_age(int week,double sow)
         fputs("建議使用接近星曆 toe 的起始時間以避免 tk 錯誤\n", stderr);
 }
 
+/* Compute corrected pseudorange and range rate */
+static void compute_range_rate(int prn,int week,double sow,
+                               const coord_t *u,const double uvel[3],
+                               double sat[3],double *rho,double *rdot)
+{
+    double pos[3], vel[3], clk[2];
+    calc_sat_position_velocity(prn, week, sow, pos, vel, clk);
+
+    double dx = pos[0]-u->xyz[0];
+    double dy = pos[1]-u->xyz[1];
+    double dz = pos[2]-u->xyz[2];
+    double range = hypot(hypot(dx,dy),dz);
+    double tau = range / CLIGHT;
+
+    pos[0] -= vel[0]*tau;
+    pos[1] -= vel[1]*tau;
+    pos[2] -= vel[2]*tau;
+
+    double xrot = pos[0] + pos[1]*OMEGA_E*tau;
+    double yrot = pos[1] - pos[0]*OMEGA_E*tau;
+    pos[0] = xrot;
+    pos[1] = yrot;
+
+    if(sat){ sat[0]=pos[0]; sat[1]=pos[1]; sat[2]=pos[2]; }
+
+    dx = pos[0]-u->xyz[0];
+    dy = pos[1]-u->xyz[1];
+    dz = pos[2]-u->xyz[2];
+    range = hypot(hypot(dx,dy),dz);
+
+    if(rho) *rho = range - CLIGHT*clk[0];
+
+    if(rdot){
+        double rvx = vel[0] - (uvel?uvel[0]:0.0);
+        double rvy = vel[1] - (uvel?uvel[1]:0.0);
+        double rvz = vel[2] - (uvel?uvel[2]:0.0);
+        *rdot = (rvx*dx + rvy*dy + rvz*dz) / range;
+    }
+}
+
 /*----------------------------------------------------*/
 int select_channels(channel_t *ch,int *n,const coord_t*u,
                     bool geo_first,int single_prn,bool no_geo,
@@ -57,13 +99,10 @@ int select_channels(channel_t *ch,int *n,const coord_t*u,
         if(single_prn>0 && prn!=single_prn) continue;
         if(no_geo && is_d2_prn(prn)) continue;
         if(meo_only && !is_meo_prn(prn)) continue;
-        double sat[3],vel[3];
-        calc_sat_position_velocity(prn,u->week,u->sow,sat,vel);
+        double sat[3], rho, rdot;
+        compute_range_rate(prn,u->week,u->sow,u,NULL,sat,&rho,&rdot);
         double enu[3]; ecef2enu(u,sat,enu);
         double el=enu_elevation_deg(enu); if(el<5.0)continue;
-        double dx=sat[0]-u->xyz[0], dy=sat[1]-u->xyz[1], dz=sat[2]-u->xyz[2];
-        double rho=hypot(hypot(dx,dy),dz);
-        double rdot=(dx*vel[0] + dy*vel[1] + dz*vel[2])/rho;
         int pri = (geo_first && is_d2_prn(prn)) ? 1 : 0;
         c[m++] = (struct cand){prn,el,rho,rdot,pri};
     }
@@ -75,7 +114,8 @@ int select_channels(channel_t *ch,int *n,const coord_t*u,
         }
     }
     *n = m<MAX_CH?m:MAX_CH;
-    for(int i=0;i<*n;++i) channel_reset(&ch[i],c[i].prn,u->week,u->sow);
+    for(int i=0;i<*n;++i)
+        channel_reset(&ch[i],c[i].prn,u->week,u->sow,c[i].rho);
     return *n;
 }
 
@@ -90,13 +130,10 @@ static void update_channels_path(const sim_config_t *cfg, channel_t *ch,int n,
 
     for(int i=0;i<n;++i){
         int prn = ch[i].prn;
-        double sat[3], vel[3];
-        calc_sat_position_velocity(prn,u->week,u->sow,sat,vel);
+        double sat[3], rho, rdot;
+        compute_range_rate(prn,u->week,u->sow,u,uvel,sat,&rho,&rdot);
         double enu[3]; ecef2enu(u,sat,enu);
         double el = enu_elevation_deg(enu);
-        double dx=sat[0]-u->xyz[0], dy=sat[1]-u->xyz[1], dz=sat[2]-u->xyz[2];
-        double rho=hypot(hypot(dx,dy),dz);
-        double rdot=(dx*(vel[0]-uvel[0]) + dy*(vel[1]-uvel[1]) + dz*(vel[2]-uvel[2]))/rho;
         if(is_d2_prn(prn) && (cfg->no_geo || cfg->zero_doppler_geo))
             rdot = 0.0;
         update_channel_dynamics(&ch[i],rho,rdot,el,gain,target_cn0,n,step_ms);
@@ -106,19 +143,14 @@ static void update_channels_path(const sim_config_t *cfg, channel_t *ch,int n,
         double t_abs = u->week*604800.0 + u->sow + dt;
         int week2 = (int)(t_abs/604800.0);
         double sow2 = t_abs - week2*604800.0;
-        double sat2[3], vel2[3];
-        calc_sat_position_velocity(prn,week2,sow2,sat2,vel2);
-        double dx2=sat2[0]-u_next->xyz[0], dy2=sat2[1]-u_next->xyz[1], dz2=sat2[2]-u_next->xyz[2];
-        double rho2=hypot(hypot(dx2,dy2),dz2);
-        double rdot2=(dx2*(vel2[0]-uvel_next[0]) +
-                      dy2*(vel2[1]-uvel_next[1]) +
-                      dz2*(vel2[2]-uvel_next[2]))/rho2;
+        double sat2[3], rho2, rdot2;
+        compute_range_rate(prn,week2,sow2,u_next,uvel_next,sat2,&rho2,&rdot2);
         if(is_d2_prn(prn) && (cfg->no_geo || cfg->zero_doppler_geo))
             rdot2 = 0.0;
         double enu2[3]; ecef2enu(u_next,sat2,enu2);
         double el2 = enu_elevation_deg(enu2);
-        double fd2 = -FCARRIER*rdot2/299792458.0;
-        double cr2 = CHIPRATE*(1.0 - rdot2/299792458.0);
+        double fd2 = -FCARRIER*rdot2/CLIGHT;
+        double cr2 = CHIPRATE*(1.0 - rdot2/CLIGHT);
         double A2 = predict_next_amp(&ch[i], rho2, el2, gain, target_cn0, n, step_ms);
         if(el2 < 5.0) A2 = 0.0;
         ch[i].fd_dot = (fd2 - ch[i].fd) / dt;

--- a/channel.c
+++ b/channel.c
@@ -157,16 +157,28 @@ static void load_ca_once(void)
     ca_ready = 1;
 }
 
-void channel_set_time(channel_t *c,int week,double sow)
+void channel_set_time(channel_t *c,int week,double sow,double rho)
 {
+    /* Transmission time accounts for signal travel time (rho/c). */
+    double tx_sow = sow - rho/299792458.0; /* seconds */
+    int tx_week = week;
+    if(tx_sow < 0.0){
+        tx_sow += 604800.0;
+        tx_week -= 1;
+    } else if(tx_sow >= 604800.0){
+        tx_sow -= 604800.0;
+        tx_week += 1;
+    }
+    c->tx_week = tx_week;
+
     /* Compute sub-ms fractional offset to align PRN/NH/data boundaries. */
-    double sow_ms = sow * 1000.0;
+    double sow_ms = tx_sow * 1000.0;
     double frac_ms = sow_ms - floor(sow_ms);
     c->code_phase = frac_ms * CODE_LEN;  /* 1 ms = 2046 chips */
 
-    double sf_start = floor(sow/6.0)*6.0;
+    double sf_start = floor(tx_sow/6.0)*6.0;
     c->sf_id = ((int)(sf_start/6.0))%5 + 1;  /* 1..5 */
-    double sub_ms = (sow - sf_start)*1000.0;
+    double sub_ms = (tx_sow - sf_start)*1000.0;
     int ms = (int)floor(sub_ms);
     if(ms < 0)      ms = 0;
     else if(ms >= 6000) ms = 5999;
@@ -176,7 +188,7 @@ void channel_set_time(channel_t *c,int week,double sow)
     /* ---- D1：以 6 s 對齊作為固定錨點 ---- */
     c->d1_sf_t0    = sf_start;
     c->d1_sf_index = 0;
-    get_subframe_bits(c->prn,c->sf_id,week,c->d1_sf_t0,6.0,c->nav_bits);
+    get_subframe_bits(c->prn,c->sf_id,c->tx_week,c->d1_sf_t0,6.0,c->nav_bits);
     if(ms == 0 && frac_ms < 1e-9){
         /* 在子幀邊界，強制對齊三個時序：PRN、NH20、NAV */
         c->code_phase = 0.0;     /* 1 ms PRN 2046 chips 從頭開始 */
@@ -186,17 +198,15 @@ void channel_set_time(channel_t *c,int week,double sow)
     /* 暫時停用 GEO/D2：不初始化任何 D2 狀態 */
 }
 
-void channel_reset(channel_t *c,int prn,int week,double sow){
+void channel_reset(channel_t *c,int prn,int week,double sow,double rho){
     memset(c,0,sizeof(*c));
     c->prn   = prn;
     load_ca_once();
 
-    /* Randomise starting carrier and code phase so I/Q averages
-       are well balanced even for short captures. */
+    /* Randomise starting carrier phase so I/Q averages are balanced. */
     c->carr_phase = ((double)rand()/(double)RAND_MAX)*PI2;
-    c->code_phase = ((double)rand()/(double)RAND_MAX)*CODE_LEN;
 
-    channel_set_time(c,week,sow);
+    channel_set_time(c,week,sow,rho);
 }
 /* 幾何→計算振幅 / 初始多普勒 */
 void update_channel_dynamics(channel_t *c,double rho,double rdot,double elev_deg,
@@ -221,11 +231,11 @@ void channel_set_fs(double sample_rate)
 void gen_samples_1ms(channel_t *c,int week,double sow,
                      int samp_per_ms,int16_t*I,int16_t*Q)
 {
-    (void)sow;
+    (void)week; (void)sow;
     if(c->bit_ptr==0 && c->ms_count==0){
         /* 一律使用固定錨點 + 6.0 * index，杜絕邊界抖動 */
         double t0 = c->d1_sf_t0 + 6.0 * c->d1_sf_index;
-        get_subframe_bits(c->prn,c->sf_id,week,t0,6.0,c->nav_bits);
+        get_subframe_bits(c->prn,c->sf_id,c->tx_week,t0,6.0,c->nav_bits);
     }
 
     double fd = c->fd;

--- a/channel.h
+++ b/channel.h
@@ -23,6 +23,8 @@ typedef struct {
     uint8_t  ms_count;      /* 0~19: ms index within data bit */
     uint8_t  nav_bits[300]; /* cached subframe bits */
 
+    int     tx_week;       /* transmission week number */
+
     /* ---- D1 固定時間錨點（6 s 子幀） ---- */
     double  d1_sf_t0;       /* 第一次對齊好的 D1 子幀起點（周內秒） */
     int     d1_sf_index;    /* 子幀索引 0..4（每 6 s 前進一次，對應頁 1..5） */
@@ -34,8 +36,8 @@ typedef struct {
     uint8_t  nav_bits_d2[300];
 } channel_t;
 
-void channel_reset(channel_t *, int prn, int week, double sow);
-void channel_set_time(channel_t *, int week, double sow);
+void channel_reset(channel_t *, int prn, int week, double sow, double rho);
+void channel_set_time(channel_t *, int week, double sow, double rho);
 void update_channel_dynamics(channel_t *, double rho, double rdot,
                              double elev_deg, double gain,
                              double target_cn0, int n_visible,

--- a/orbits.c
+++ b/orbits.c
@@ -35,7 +35,7 @@ static double kepler(double M, double e)
 /* --------------------------------------------------------------*/
 /*          主要 API：回傳 ECEF 位置 xyz 與速度 vel               */
 void calc_sat_position_velocity(int prn, int week, double sow,
-                                double *xyz, double *vel)
+                                double *xyz, double *vel, double *clk)
 {
     const ephemeris_t *ep = &eph[prn];        /* 全域星曆陣列 (外部定義) */
 
@@ -117,6 +117,17 @@ void calc_sat_position_velocity(int prn, int week, double sow,
         y_dot = (x_op_dot - y_op * cosi * Omega_dot) * sinO
               + (x_op * Omega_dot + y_op_dot * cosi - y_op * sini * i_dot) * cosO;
         z_dot = y_op_dot * sini + y_op * cosi * i_dot;
+    }
+
+    /* -------- 衛星鐘差 (含相對論效應與 TGD1) ----------------- */
+    if (clk) {
+        const double relativistic = -4.442807633e-10 * ep->e * ep->sqrtA * sinE;
+        const double t_clk_ref = ep->week * 604800.0 + ep->toc;
+        double tk_clk = t_sim - t_clk_ref;
+        if (tk_clk > 302400.0) tk_clk -= 604800.0;
+        if (tk_clk < -302400.0) tk_clk += 604800.0;
+        clk[0] = ep->af0 + tk_clk * (ep->af1 + tk_clk * ep->af2) + relativistic - ep->tgd1;
+        clk[1] = ep->af1 + 2.0 * tk_clk * ep->af2;
     }
 
     if (is_geo_prn(prn)) {

--- a/orbits.h
+++ b/orbits.h
@@ -1,7 +1,8 @@
 #ifndef ORBITS_H
 #define ORBITS_H
+/* Compute satellite position, velocity and clock bias/drift at given time */
 void calc_sat_position_velocity(int prn,int week,double sow,
-                                double *xyz,double *vel);
+                                double *xyz,double *vel,double *clk);
 #endif
 
 

--- a/tests/test_nh_prn.c
+++ b/tests/test_nh_prn.c
@@ -23,7 +23,7 @@ int main(void)
 
     int prn = 8; /* MEO/IGSO uses D1 with NH code */
     channel_t ch;
-    channel_reset(&ch, prn, nav_week, 0.0);
+    channel_reset(&ch, prn, nav_week, 0.0, 0.0);
     ch.carr_phase = 0.0;
     ch.code_phase = 0.1; /* avoid boundary ambiguity */
     update_channel_dynamics(&ch, 2.0e7, 0.0, 90.0, 1.0, cfg.target_cn0, 1, 1.0);

--- a/tests/test_orbits.c
+++ b/tests/test_orbits.c
@@ -68,7 +68,7 @@ int main(void)
 
 
             double xyz[3];
-            calc_sat_position_velocity(prn, bw, bsow, xyz, NULL);
+            calc_sat_position_velocity(prn, bw, bsow, xyz, NULL, NULL);
 
             double dx = xyz[0] - x*1000.0;
             double dy = xyz[1] - y*1000.0;

--- a/tests/test_prn_d1d2.c
+++ b/tests/test_prn_d1d2.c
@@ -18,7 +18,7 @@ int main(void){
     assert(!is_d2_prn(8));
 
     channel_t c8;
-    channel_reset(&c8, 8, nav_week, 0.0);
+    channel_reset(&c8, 8, nav_week, 0.0, 0.0);
     channel_set_fs(FS_OUTPUT_HZ);
     int samp_per_ms = (int)(FS_OUTPUT_HZ/1000.0 + 0.5);
     int16_t I[samp_per_ms], Q[samp_per_ms];


### PR DESCRIPTION
## Summary
- compute satellite clock bias/drift in `calc_sat_position_velocity`
- use signal transit time and Earth-rotation correction to derive pseudorange and range rate
- align channel timing with pseudorange for Doppler-consistent code and data phase

## Testing
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_68920d8a1d0883278bea512f83e1444f