### PR TITLE
Generate subframes 2 and 3 on demand

### DIFF
--- a/bdssim.c
+++ b/bdssim.c
@@ -184,8 +184,6 @@ void generate_signal(const sim_config_t *cfg)
     coord_t ref_llh=usr;              /* 保存經緯度作旋轉基準 */
     static_user_at(usr.week,usr.sow,&ref_llh,&usr,NULL);
 
-    navbits_init();
-
     /* 檢查 start 時間是否與星曆 toe 接近 */
     check_ephemeris_age(usr.week, usr.sow);
 

--- a/navbits.c
+++ b/navbits.c
@@ -320,19 +320,6 @@ static void build_subframe5_d1(uint8_t *out, double sow, double frame_len)
     put_word(out, 270, build_word(filler, 22));
 }
 
-static uint8_t sf_static[MAX_SAT][4][SF_STREAM_LEN]; /* subframe 2-5 */
-
-void navbits_init(void)
-{
-    for(int prn=1;prn<=prn_max;prn++){
-        B1I_D1_Frame frm;
-        frame_from_ephemeris(&eph[prn], &frm);
-        build_subframe2_d1(sf_static[prn][0], &frm, 0, 6.0);
-        build_subframe3_d1(sf_static[prn][1], &frm, 0, 6.0);
-        build_subframe4_d1(sf_static[prn][2],0,6.0);
-        build_subframe5_d1(sf_static[prn][3],0,6.0);
-    }
-}
 
 /* 根據時間取得子帧 bit 流 (300 bits) */
 void get_subframe_bits(int prn,int sf_id,int week,double sow,double frame_len,uint8_t *out)

--- a/navbits.h
+++ b/navbits.h
@@ -10,7 +10,6 @@
 
 #define SF_STREAM_LEN (SUBFRAME_BITS)
 
-void navbits_init(void);
 void get_subframe_bits(int prn, int sf_id, int week, double sow,
                        double frame_len, uint8_t *out); /* sf_id=1..5 */
 


### PR DESCRIPTION
## Summary
- Remove navbits_init and precomputed buffers so subframes 2 and 3 are assembled with current time like subframe 1.
- Drop navbits_init call from simulation startup.

## Testing
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_689ef56a17cc8327aa2a6009f91b6dd2