### PR TITLE
Print ephemeris parameters for single satellite

### DIFF
--- a/main.c
+++ b/main.c
@@ -10,6 +10,7 @@
 #include "path.h"
 #include "channel.h"        /* g_target_cn0 */
 #include "coord.h"
+#include "navbits.h"
 
 /* ───────────────────────────── */
 static void usage(const char *p)
@@ -273,6 +274,9 @@ int main(int argc,char *argv[])
     double fs_out = cfg.byte_output ? 25.0 : FS_OUTPUT_HZ/1e6;
     printf("\n[cfg] Fs %.2fMHz  Gain %.2f\n\n",
            fs_out, cfg.gain);
+
+    if(cfg.single_prn > 0)
+        print_ephemeris_params(cfg.single_prn);
 
     /* 4. 產生基帶 ----------------------------------- */
     generate_signal(&cfg);

--- a/navbits.c
+++ b/navbits.c
@@ -2,6 +2,7 @@
 
 #include <math.h>
 #include <string.h>
+#include <stdio.h>
 #include "navbits.h"
 #include "bch.h"
 #include "globals.h"
@@ -60,6 +61,7 @@ static void frame_from_ephemeris(const ephemeris_t *e, B1I_D1_Frame *f)
     f->cus      = (int32_t)llround(e->cus / pow(2, -31));
     f->cic      = (int32_t)llround(e->cic / pow(2, -31));
     f->cis      = (int32_t)llround(e->cis / pow(2, -31));
+    f->aode     = e->aode & 0x1F;
     f->idot     = (int32_t)llround(rad_to_sc(e->idot) / pow(2, -43));
     f->omegadot = (int32_t)llround(rad_to_sc(e->omegadot) / pow(2, -43));
     
@@ -110,43 +112,35 @@ static void build_subframe1_d1(uint8_t *out, const B1I_D1_Frame *f, int week, do
     put_word(out,30, build_word(w2,22));
 
     /* word3: WN + toc high 9 bits */
-    uint32_t toc_ticks = f->toc;
-    uint32_t w3 = ((week & 0x1FFF) << 9) | ((toc_ticks >> 8) & 0x1FF);
+    uint32_t w3 = ((week & 0x1FFF) << 9) | ((f->toc >> 8) & 0x1FF);
     put_word(out,60, build_word(w3,22));
 
     /* word4: toc low 8 + TGD1 + TGD2 high 4 */
-    int32_t tgd1_i = f->tgd1;
-    int32_t tgd2_i = f->tgd2;
-    uint32_t w4 = ((toc_ticks & 0xFF) << 14) | ((tgd1_i & 0x3FF) << 4) | ((tgd2_i >> 6) & 0xF);
+    uint32_t w4 = ((f->toc & 0xFF) << 14) | ((f->tgd1 & 0x3FF) << 4) | ((f->tgd2 >> 6) & 0xF);
     put_word(out,90, build_word(w4,22));
 
     /* word5: TGD2 low 6 + alpha0 + alpha1 */
-    uint32_t w5 = ((tgd2_i & 0x3F) << 16) | ((f->alpha[0] & 0xFF) << 8) | (f->alpha[1] & 0xFF);
+    uint32_t w5 = ((f->tgd2 & 0x3F) << 16) | ((f->alpha[0] & 0xFF) << 8) | (f->alpha[1] & 0xFF);
     put_word(out,120, build_word(w5,22));
 
     /* word6: alpha2 + alpha3 + beta0 high 6 */
-    uint32_t beta0 = f->beta[0];
-    uint32_t w6 = ((f->alpha[2] & 0xFF) << 14) | ((f->alpha[3] & 0xFF) << 6) | ((beta0 >> 2) & 0x3F);
+    uint32_t w6 = ((f->alpha[2] & 0xFF) << 14) | ((f->alpha[3] & 0xFF) << 6) | ((f->beta[0] >> 2) & 0x3F);
     put_word(out,150, build_word(w6,22));
 
     /* word7: beta0 low 2 + beta1 + beta2 + beta3 high 4 */
-    uint32_t beta1 = f->beta[1], beta2 = f->beta[2], beta3 = f->beta[3];
-    uint32_t w7 = ((beta0 & 0x3) << 20) | ((beta1 & 0xFF) << 12) | ((beta2 & 0xFF) << 4) | ((beta3 >> 4) & 0xF);
+    uint32_t w7 = ((f->beta[0] & 0x3) << 20) | ((f->beta[1] & 0xFF) << 12) | ((f->beta[2] & 0xFF) << 4) | ((f->beta[3] >> 4) & 0xF);
     put_word(out,180, build_word(w7,22));
 
     /* word8: beta3 low 4 + a2 + a0 high 7 */
-    int32_t a0_i = f->a0;
-    int32_t a1_i = f->a1;
-    int32_t a2_i = f->a2;
-    uint32_t w8 = ((beta3 & 0xF) << 18) | ((a2_i & 0x7FF) << 7) | (((uint32_t)a0_i >> 17) & 0x7F);
+    uint32_t w8 = ((f->beta[3] & 0xF) << 18) | ((f->a2 & 0x7FF) << 7) | ((f->a0 >> 17) & 0x7F);
     put_word(out,210, build_word(w8,22));
 
     /* word9: a0 low 17 + a1 high 5 */
-    uint32_t w9 = ((uint32_t)a0_i & 0x1FFFF) << 5 | (((uint32_t)a1_i >> 17) & 0x1F);
+    uint32_t w9 = ((f->a0 & 0x1FFFF) << 5) | ((f->a1 >> 17) & 0x1F);
     put_word(out,240, build_word(w9,22));
 
     /* word10: a1 low 17 + AODE */
-    uint32_t w10 = (((uint32_t)a1_i & 0x1FFFF) << 5) | (f->aode & 0x1F);
+    uint32_t w10 = ((f->a1 & 0x1FFFF) << 5) | (f->aode & 0x1F);
     put_word(out,270, build_word(w10,22));
 }
 
@@ -156,50 +150,50 @@ static void build_subframe2_d1(uint8_t *out, const B1I_D1_Frame *f, double sow, 
     memset(out, 0, SF_STREAM_LEN);
 
     uint32_t sow_int = (uint32_t)(floor(sow / frame_len) * frame_len);
-    uint32_t p;
+    uint32_t w;
 
     /* Word1: preamble + reserved + FraID=2 + SOW[19:12] */
-    p = 0x712;
-    p = (p << 4);
-    p = (p << 3) | 2;
-    p = (p << 8) | ((sow_int >> 12) & 0xFF);
-    put_word(out, 0, build_word(p, 26));
+    w = 0x712;
+    w = (w << 4);
+    w = (w << 3) | 2;
+    w = (w << 8) | ((sow_int >> 12) & 0xFF);
+    put_word(out, 0, build_word(w, 26));
 
     /* Word2: SOW[11:0] + delta_n high 10 bits */
-    p = ((sow_int & 0xFFF) << 10) | ((uint32_t)f->delta_n >> 6 & 0x3FF);
-    put_word(out, 30, build_word(p, 22));
+    uint32_t w2 = ((sow_int & 0xFFF) << 10) | ((uint32_t)f->delta_n >> 6 & 0x3FF);
+    put_word(out, 30, build_word(w2, 22));
 
     /* Word3: delta_n low 6 + Cuc high 16 */
-    p = ((uint32_t)f->delta_n & 0x3F) << 16 | ((uint32_t)f->cuc >> 2 & 0xFFFF);
-    put_word(out, 60, build_word(p, 22));
+    uint32_t w3 = ((uint32_t)f->delta_n & 0x3F) << 16 | ((uint32_t)f->cuc >> 2 & 0xFFFF);
+    put_word(out, 60, build_word(w3, 22));
 
     /* Word4: Cuc low 2 + M0 high 20 */
-    p = ((uint32_t)f->cuc & 0x3) << 20 | ((uint32_t)f->M0 >> 12 & 0xFFFFF);
-    put_word(out, 90, build_word(p, 22));
+    uint32_t w4 = ((uint32_t)f->cuc & 0x3) << 20 | ((uint32_t)f->M0 >> 12 & 0xFFFFF);
+    put_word(out, 90, build_word(w4, 22));
 
     /* Word5: M0 low 12 + e high 10 */
-    p = ((uint32_t)f->M0 & 0xFFF) << 10 | ((uint32_t)f->e >> 22 & 0x3FF);
-    put_word(out, 120, build_word(p, 22));
+    uint32_t w5 = ((uint32_t)f->M0 & 0xFFF) << 10 | ((uint32_t)f->e >> 22 & 0x3FF);
+    put_word(out, 120, build_word(w5, 22));
 
     /* Word6: e low 22 */
-    p = (uint32_t)f->e & 0x3FFFFF;
-    put_word(out, 150, build_word(p, 22));
+    uint32_t w6 = (uint32_t)f->e & 0x3FFFFF;
+    put_word(out, 150, build_word(w6, 22));
 
     /* Word7: Cus + Crc high 4 */
-    p = ((uint32_t)f->cus & 0x3FFFF) << 4 | ((uint32_t)f->crc >> 14 & 0xF);
-    put_word(out, 180, build_word(p, 22));
+    uint32_t w7 = ((uint32_t)f->cus & 0x3FFFF) << 4 | ((uint32_t)f->crc >> 14 & 0xF);
+    put_word(out, 180, build_word(w7, 22));
 
     /* Word8: Crc low 14 + Crs high 8 */
-    p = ((uint32_t)f->crc & 0x3FFF) << 8 | ((uint32_t)f->crs >> 10 & 0xFF);
-    put_word(out, 210, build_word(p, 22));
+    uint32_t w8 = ((uint32_t)f->crc & 0x3FFF) << 8 | ((uint32_t)f->crs >> 10 & 0xFF);
+    put_word(out, 210, build_word(w8, 22));
 
     /* Word9: Crs low 10 + sqrtA high 12 */
-    p = ((uint32_t)f->crs & 0x3FF) << 12 | ((uint32_t)f->sqrtA >> 20 & 0xFFF);
-    put_word(out, 240, build_word(p, 22));
+    uint32_t w9 = ((uint32_t)f->crs & 0x3FF) << 12 | ((uint32_t)f->sqrtA >> 20 & 0xFFF);
+    put_word(out, 240, build_word(w9, 22));
 
     /* Word10: sqrtA low 20 + toe high 2 */
-    p = ((uint32_t)f->sqrtA & 0xFFFFF) << 2 | ((f->toe >> 15) & 0x3);
-    put_word(out, 270, build_word(p, 22));
+    uint32_t w10 = ((uint32_t)f->sqrtA & 0xFFFFF) << 2 | ((f->toe >> 15) & 0x3);
+    put_word(out, 270, build_word(w10, 22));
 }
 
 /* --------------------------------- 子帧 3 ----------------------------------- */
@@ -208,50 +202,50 @@ static void build_subframe3_d1(uint8_t *out, const B1I_D1_Frame *f, double sow, 
     memset(out, 0, SF_STREAM_LEN);
 
     uint32_t sow_int = (uint32_t)(floor(sow / frame_len) * frame_len);
-    uint32_t p;
+    uint32_t w;
 
     /* Word1: preamble + reserved + FraID=3 + SOW[19:12] */
-    p = 0x712;
-    p = (p << 4);
-    p = (p << 3) | 3;
-    p = (p << 8) | ((sow_int >> 12) & 0xFF);
-    put_word(out, 0, build_word(p, 26));
+    w = 0x712;
+    w = (w << 4);
+    w = (w << 3) | 3;
+    w = (w << 8) | ((sow_int >> 12) & 0xFF);
+    put_word(out, 0, build_word(w, 26));
 
     /* Word2: SOW[11:0] + toe bits[14:5] */
-    p = ((sow_int & 0xFFF) << 10) | ((f->toe >> 5) & 0x3FF);
-    put_word(out, 30, build_word(p, 22));
+    uint32_t w2 = ((sow_int & 0xFFF) << 10) | ((f->toe >> 5) & 0x3FF);
+    put_word(out, 30, build_word(w2, 22));
 
     /* Word3: toe low5 + i0 high17 */
-    p = ((f->toe & 0x1F) << 17) | ((uint32_t)f->i0 >> 15 & 0x1FFFF);
-    put_word(out, 60, build_word(p, 22));
+    uint32_t w3 = ((f->toe & 0x1F) << 17) | ((uint32_t)f->i0 >> 15 & 0x1FFFF);
+    put_word(out, 60, build_word(w3, 22));
 
     /* Word4: i0 low15 + Cic high7 */
-    p = ((uint32_t)f->i0 & 0x7FFF) << 7 | ((uint32_t)f->cic >> 11 & 0x7F);
-    put_word(out, 90, build_word(p, 22));
+    uint32_t w4 = ((uint32_t)f->i0 & 0x7FFF) << 7 | ((uint32_t)f->cic >> 11 & 0x7F);
+    put_word(out, 90, build_word(w4, 22));
 
     /* Word5: Cic low11 + omegadot high11 */
-    p = ((uint32_t)f->cic & 0x7FF) << 11 | ((uint32_t)f->omegadot >> 13 & 0x7FF);
-    put_word(out, 120, build_word(p, 22));
+    uint32_t w5 = ((uint32_t)f->cic & 0x7FF) << 11 | ((uint32_t)f->omegadot >> 13 & 0x7FF);
+    put_word(out, 120, build_word(w5, 22));
 
     /* Word6: omegadot low13 + Cis high9 */
-    p = ((uint32_t)f->omegadot & 0x1FFF) << 9 | ((uint32_t)f->cis >> 9 & 0x1FF);
-    put_word(out, 150, build_word(p, 22));
+    uint32_t w6 = ((uint32_t)f->omegadot & 0x1FFF) << 9 | ((uint32_t)f->cis >> 9 & 0x1FF);
+    put_word(out, 150, build_word(w6, 22));
 
     /* Word7: Cis low9 + IDOT high13 */
-    p = ((uint32_t)f->cis & 0x1FF) << 13 | ((uint32_t)f->idot >> 1 & 0x1FFF);
-    put_word(out, 180, build_word(p, 22));
+    uint32_t w7 = ((uint32_t)f->cis & 0x1FF) << 13 | ((uint32_t)f->idot >> 1 & 0x1FFF);
+    put_word(out, 180, build_word(w7, 22));
 
     /* Word8: IDOT low1 + omega0 high21 */
-    p = ((uint32_t)f->idot & 0x1) << 21 | ((uint32_t)f->omega0 >> 11 & 0x1FFFFF);
-    put_word(out, 210, build_word(p, 22));
+    uint32_t w8 = ((uint32_t)f->idot & 0x1) << 21 | ((uint32_t)f->omega0 >> 11 & 0x1FFFFF);
+    put_word(out, 210, build_word(w8, 22));
 
     /* Word9: omega0 low11 + omega high11 */
-    p = ((uint32_t)f->omega0 & 0x7FF) << 11 | ((uint32_t)f->omega >> 21 & 0x7FF);
-    put_word(out, 240, build_word(p, 22));
+    uint32_t w9 = ((uint32_t)f->omega0 & 0x7FF) << 11 | ((uint32_t)f->omega >> 21 & 0x7FF);
+    put_word(out, 240, build_word(w9, 22));
 
     /* Word10: omega low21 + reserved bit */
-    p = ((uint32_t)f->omega & 0x1FFFFF) << 1;
-    put_word(out, 270, build_word(p, 22));
+    uint32_t w10 = ((uint32_t)f->omega & 0x1FFFFF) << 1;
+    put_word(out, 270, build_word(w10, 22));
 }
 
 /* --------------------------------- 子帧 4 ----------------------------------- */
@@ -344,5 +338,27 @@ void get_subframe_bits(int prn,int sf_id,int week,double sow,double frame_len,ui
     }else{
         memset(out,0,SF_STREAM_LEN);
     }
+}
+
+/* Dump broadcast ephemeris parameters for a given PRN */
+void print_ephemeris_params(int prn)
+{
+    B1I_D1_Frame f;
+    frame_from_ephemeris(&eph[prn], &f);
+    printf("[PRN %d] toc=%u aodc=%u aode=%u urai=%u satH1=%u\n",
+           prn, f.toc, f.aodc, f.aode, f.urai, f.satH1);
+    printf("[PRN %d] tgd1=%d tgd2=%d af0=%d af1=%d af2=%d\n",
+           prn, f.tgd1, f.tgd2, f.a0, f.a1, f.a2);
+    printf("[PRN %d] alpha=%d,%d,%d,%d beta=%d,%d,%d,%d\n",
+           prn, f.alpha[0], f.alpha[1], f.alpha[2], f.alpha[3],
+           f.beta[0], f.beta[1], f.beta[2], f.beta[3]);
+    printf("[PRN %d] delta_n=%d M0=%d e=%u sqrtA=%u\n",
+           prn, f.delta_n, f.M0, f.e, f.sqrtA);
+    printf("[PRN %d] cuc=%d cus=%d crc=%d crs=%d\n",
+           prn, f.cuc, f.cus, f.crc, f.crs);
+    printf("[PRN %d] toe=%u i0=%d omega0=%d omega=%d\n",
+           prn, f.toe, f.i0, f.omega0, f.omega);
+    printf("[PRN %d] omegadot=%d idot=%d cic=%d cis=%d\n",
+           prn, f.omegadot, f.idot, f.cic, f.cis);
 }
 

--- a/navbits.h
+++ b/navbits.h
@@ -13,6 +13,8 @@
 void get_subframe_bits(int prn, int sf_id, int week, double sow,
                        double frame_len, uint8_t *out); /* sf_id=1..5 */
 
+void print_ephemeris_params(int prn);
+
 #endif
 
 


### PR DESCRIPTION
## Summary
- refactor B1I subframe builders and include AODE mapping
- add `print_ephemeris_params` helper to dump broadcast parameters
- print ephemeris when running in single-PRN mode

## Testing
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_68a0a163072883278837ff3b7f28aa85