### PR TITLE
Use CLIGHT macro for speed of light

### DIFF
--- a/bdssim.c
+++ b/bdssim.c
@@ -12,12 +12,11 @@
 #include "navbits.h"
 #include "timeconv.h"
 #include "path.h"
-#include "globals.h"     /* nav_week */
+#include "globals.h"     /* nav_week, CLIGHT */
 #define FSAMP_DEF FS_OUTPUT_HZ    /* default 6.144 MHz for 16-bit I/Q output */
 #define FSAMP_BYTE 25.0e6    /* 25 MHz when --byte is used */
 #define FCARRIER   1561.098e6      /* B1I carrier */
 #define CHIPRATE   2.046e6
-#define CLIGHT     299792458.0
 #define OMEGA_E    7.2921150e-5
 
 /* ========= 振幅計算與 int16 飽和保護 ========= */
@@ -279,7 +278,7 @@ void generate_signal(const sim_config_t *cfg)
         }
         if(ms==0){
             for(int i=0;i<n_ch;++i){
-                double rdot = -ch[i].fd*299792458.0/FCARRIER;
+                double rdot = -ch[i].fd*CLIGHT/FCARRIER;
                 printf("[ch%02d] rdot %.2f fd %.2fHz\n", ch[i].prn, rdot, ch[i].fd);
             }
         }

--- a/channel.c
+++ b/channel.c
@@ -160,7 +160,7 @@ static void load_ca_once(void)
 void channel_set_time(channel_t *c,int week,double sow,double rho)
 {
     /* Transmission time accounts for signal travel time (rho/c). */
-    double tx_sow = sow - rho/299792458.0; /* seconds */
+    double tx_sow = sow - rho/CLIGHT; /* seconds */
     int tx_week = week;
     if(tx_sow < 0.0){
         tx_sow += 604800.0;
@@ -218,8 +218,8 @@ void update_channel_dynamics(channel_t *c,double rho,double rdot,double elev_deg
     c->amp = smooth_amp(c->amp, A_new, dt_ms);
     c->amp_dot = 0.0;
     c->elev_deg = elev_deg;
-    c->fd  = -FCARRIER*rdot/299792458.0;               /* Doppler (Hz) */
-    c->code_rate = CHIPRATE*(1.0 - rdot/299792458.0);  /* Code frequency (Hz) */
+    c->fd  = -FCARRIER*rdot/CLIGHT;               /* Doppler (Hz) */
+    c->code_rate = CHIPRATE*(1.0 - rdot/CLIGHT);  /* Code frequency (Hz) */
 }
 
 void channel_set_fs(double sample_rate)

--- a/globals.h
+++ b/globals.h
@@ -9,6 +9,8 @@
 #define CN0_TARGET_DBHZ   42.0        /* 40–45 dB-Hz 常用 */
 #define HEADROOM_RATIO    0.80        /* 約 -2 dB 頭房，防飽和 */
 #define AMP_SMOOTH_TC_MS  1000        /* 振幅平滑時間常數 */
+/* Physical constant */
+#define CLIGHT            299792458.0 /* Speed of light (m/s) */
 /* Per-orbit-class amplitude offsets (dB) */
 #define GAIN_MEO_DB   +1.5
 #define GAIN_IGSO_DB  +1.5


### PR DESCRIPTION
## Summary
- Define global `CLIGHT` constant and use it consistently across channel timing and Doppler calculations.
- Replace hard-coded speed-of-light literals with the shared macro to avoid precision mismatches.

## Testing
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_68a181f21a00832788ac049e417946f3