### PR TITLE
Synchronize D1 subframe timing to transmitter frame

### DIFF
--- a/bdssim.c
+++ b/bdssim.c
@@ -182,6 +182,20 @@ static void update_channels_path(channel_t *ch,int n,
         double enu[3]; ecef2enu(u,sat,enu);
         double el = enu_elevation_deg(enu);
         update_channel_dynamics(&ch[i],rho,rdot,el,gain,target_cn0,n,step_ms);
+
+        /* 每逢接收端時間靠近 6 s 邊界時，重新計算 tx 子幀錨點 */
+        const double SIX = 6.0;
+        const double EPS = 0.002; /* 2 ms */
+        double sow = u->sow;
+        if(fmod(sow, SIX) < EPS){
+            double tx_sow = sow - ch[i].last_rho / CLIGHT;
+            if(fabs(tx_sow - ch[i].d1_sf_t0) > EPS){
+                ch[i].d1_sf_t0 = floor(tx_sow / SIX) * SIX;
+                ch[i].tx_week = u->week;
+                ch[i].d1_sf_index = (int)floor((tx_sow - ch[i].d1_sf_t0)/SIX + 0.5);
+            }
+        }
+
         if(el < 5.0) ch[i].amp = 0.0;     /* below horizon → mute */
 
         /* predict next dynamics using next position/velocity */

--- a/channel.c
+++ b/channel.c
@@ -152,6 +152,7 @@ void channel_set_time(channel_t *c,int week,double sow,double rho)
         tx_week += 1;
     }
     c->tx_week = tx_week;
+    c->last_rho = rho;
 
     /* Compute sub-ms fractional offset to align PRN/NH/data boundaries. */
     double sow_ms = tx_sow * 1000.0;
@@ -170,7 +171,8 @@ void channel_set_time(channel_t *c,int week,double sow,double rho)
     /* ---- D1：以 6 s 對齊作為固定錨點 ---- */
     c->d1_sf_t0    = sf_start;
     c->d1_sf_index = 0;
-    get_subframe_bits(c->prn,c->sf_id,c->tx_week,c->d1_sf_t0,6.0,c->nav_bits);
+    double sow_tx_anchor = c->d1_sf_t0 + 6.0 * c->d1_sf_index;
+    get_subframe_bits(c->prn,c->sf_id,c->tx_week,sow_tx_anchor,6.0,c->nav_bits);
     if(ms == 0 && frac_ms < 1e-9){
         /* 在子幀邊界，強制對齊三個時序：PRN、NH20、NAV */
         c->code_phase = 0.0;     /* 1 ms PRN 2046 chips 從頭開始 */
@@ -201,6 +203,7 @@ void update_channel_dynamics(channel_t *c,double rho,double rdot,double elev_deg
     c->elev_deg = elev_deg;
     c->fd  = -FCARRIER*rdot/CLIGHT;               /* Doppler (Hz) */
     c->code_rate = CHIPRATE*(1.0 - rdot/CLIGHT);  /* Code frequency (Hz) */
+    c->last_rho = rho;
 }
 
 void channel_set_fs(double sample_rate)
@@ -215,8 +218,8 @@ void gen_samples_1ms(channel_t *c,int week,double sow,
     (void)week; (void)sow;
     if(c->bit_ptr==0 && c->ms_count==0){
         /* 一律使用固定錨點 + 6.0 * index，杜絕邊界抖動 */
-        double t0 = c->d1_sf_t0 + 6.0 * c->d1_sf_index;
-        get_subframe_bits(c->prn,c->sf_id,c->tx_week,t0,6.0,c->nav_bits);
+        double sow_tx_anchor = c->d1_sf_t0 + 6.0 * c->d1_sf_index;
+        get_subframe_bits(c->prn,c->sf_id,c->tx_week,sow_tx_anchor,6.0,c->nav_bits);
     }
 
     double fd = c->fd;

--- a/channel.h
+++ b/channel.h
@@ -17,6 +17,7 @@ typedef struct {
     double  carr_phase;   /* rad                       */
     double  code_phase;   /* chips                     */
     double  elev_deg;     /* satellite elevation (deg) */
+    double  last_rho;     /* 最近一次幾何距離 (m) */
     uint16_t code_ptr;
     uint16_t bit_ptr;
     uint8_t  sf_id;


### PR DESCRIPTION
## Summary
- track last geometric range per channel
- recalibrate D1 subframe anchor near 6 s boundaries using transmit time
- generate subframe bits from transmit-side anchor to avoid boundary jitter

## Testing
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_68a2f56f13748327b79ffea54d52c960