### PR TITLE
Use llround for SOW and drop re-anchor logic

### DIFF
--- a/bdssim.c
+++ b/bdssim.c
@@ -183,19 +183,6 @@ static void update_channels_path(channel_t *ch,int n,
         double el = enu_elevation_deg(enu);
         update_channel_dynamics(&ch[i],rho,rdot,el,gain,target_cn0,n,step_ms);
 
-        /* 每逢接收端時間靠近 6 s 邊界時，重新計算 tx 子幀錨點 */
-        const double SIX = 6.0;
-        const double EPS = 0.002; /* 2 ms */
-        double sow = u->sow;
-        if(fmod(sow, SIX) < EPS){
-            double tx_sow = sow - ch[i].last_rho / CLIGHT;
-            if(fabs(tx_sow - ch[i].d1_sf_t0) > EPS){
-                ch[i].d1_sf_t0 = floor(tx_sow / SIX) * SIX;
-                ch[i].tx_week = u->week;
-                ch[i].d1_sf_index = (int)floor((tx_sow - ch[i].d1_sf_t0)/SIX + 0.5);
-            }
-        }
-
         if(el < 5.0) ch[i].amp = 0.0;     /* below horizon → mute */
 
         /* predict next dynamics using next position/velocity */

--- a/navbits.c
+++ b/navbits.c
@@ -103,7 +103,7 @@ static void build_subframe1_d1(uint8_t *out, const B1I_D1_Frame *f, int week, do
      * corresponds to the rising edge of the frame sync
      * at the beginning of the subframe.
      */
-    uint32_t sow_int = (uint32_t)(floor(sow/frame_len)*frame_len);
+    uint32_t sow_int = (uint32_t)llround(sow);
     info = (info<<8) | ((sow_int>>12) & 0xFF);
     put_word(out,0, build_word(info, 26));
 
@@ -149,7 +149,7 @@ static void build_subframe2_d1(uint8_t *out, const B1I_D1_Frame *f, double sow, 
 {
     memset(out, 0, SF_STREAM_LEN);
 
-    uint32_t sow_int = (uint32_t)(floor(sow / frame_len) * frame_len);
+    uint32_t sow_int = (uint32_t)llround(sow);
     uint32_t w;
 
     /* Word1: preamble + reserved + FraID=2 + SOW[19:12] */
@@ -201,7 +201,7 @@ static void build_subframe3_d1(uint8_t *out, const B1I_D1_Frame *f, double sow, 
 {
     memset(out, 0, SF_STREAM_LEN);
 
-    uint32_t sow_int = (uint32_t)(floor(sow / frame_len) * frame_len);
+    uint32_t sow_int = (uint32_t)llround(sow);
     uint32_t w;
 
     /* Word1: preamble + reserved + FraID=3 + SOW[19:12] */
@@ -257,7 +257,7 @@ static void build_subframe4_d1(uint8_t *out, double sow, double frame_len)
 
     memset(out, 0, SF_STREAM_LEN);
 
-    uint32_t sow_int = (uint32_t)(floor(sow / frame_len) * frame_len);
+    uint32_t sow_int = (uint32_t)llround(sow);
 
     /* word1: preamble + reserved + FraID=4 + SOW[19:12] */
     uint32_t w = 0x712;
@@ -288,7 +288,7 @@ static void build_subframe5_d1(uint8_t *out, double sow, double frame_len)
 
     memset(out, 0, SF_STREAM_LEN);
 
-    uint32_t sow_int = (uint32_t)(floor(sow / frame_len) * frame_len);
+    uint32_t sow_int = (uint32_t)llround(sow);
 
     /* word1: preamble + reserved + FraID=5 + SOW[19:12] */
     uint32_t w = 0x712;
@@ -318,7 +318,7 @@ static void build_subframe5_d1(uint8_t *out, double sow, double frame_len)
 /* 根據時間取得子帧 bit 流 (300 bits) */
 void get_subframe_bits(int prn,int sf_id,int week,double sow,double frame_len,uint8_t *out)
 {
-    double start = floor(sow/frame_len)*frame_len;
+    double start = llround(sow);
     B1I_D1_Frame frm, *pf = NULL;
     if(sf_id >=1 && sf_id <=3){
         frame_from_ephemeris(&eph[prn], &frm);


### PR DESCRIPTION
## Summary
- round SOW to the nearest integer instead of flooring to prior 6-second frame
- drop receiver-time 6 s boundary re-anchor logic from channel update

## Testing
- `make check`
- `./tests/test_pnum_cycle` *(fails: assertion `w2 == expect`)*

------
https://chatgpt.com/codex/tasks/task_e_68a34d3c29dc8327b89e2c765fad5f75