### PR TITLE
Centralize transmit time

### DIFF
--- a/bdssim.c
+++ b/bdssim.c
@@ -52,8 +52,15 @@ static void compute_range_rate(int prn,int week,double sow,
                                const coord_t *u,const double uvel[3],
                                double sat[3],double *rho,double *rdot)
 {
-    double pos[3], vel[3];
-    calc_sat_position_velocity(prn, week, sow, pos, vel, NULL);
+    /* Satellite clock at global transmit time */
+    double clk_tx[2], pos_dummy[3], vel_dummy[3];
+    calc_sat_position_velocity(prn, week, sow, pos_dummy, vel_dummy, clk_tx);
+    double t_sv = week*604800.0 + sow - clk_tx[0];
+    int week_sv = (int)(t_sv/604800.0);
+    double sow_sv = t_sv - week_sv*604800.0;
+
+    double pos[3], vel[3], clk_sv[2];
+    calc_sat_position_velocity(prn, week_sv, sow_sv, pos, vel, clk_sv);
 
     double dx = pos[0]-u->xyz[0];
     double dy = pos[1]-u->xyz[1];
@@ -61,10 +68,7 @@ static void compute_range_rate(int prn,int week,double sow,
     double range = hypot(hypot(dx,dy),dz);
     double tau = range / CLIGHT;
 
-    pos[0] -= vel[0]*tau;
-    pos[1] -= vel[1]*tau;
-    pos[2] -= vel[2]*tau;
-
+    /* Earth rotation during signal travel */
     double xrot = pos[0] + pos[1]*OMEGA_E*tau;
     double yrot = pos[1] - pos[0]*OMEGA_E*tau;
     pos[0] = xrot;
@@ -77,24 +81,14 @@ static void compute_range_rate(int prn,int week,double sow,
     dz = pos[2]-u->xyz[2];
     range = hypot(hypot(dx,dy),dz);
 
-    /* Evaluate satellite clock bias at transmit time (sow - tau) */
-    {
-        double clk_tx[2], pos_dummy[3], vel_dummy[3];
-        calc_sat_position_velocity(prn, week, sow - tau, pos_dummy, vel_dummy, clk_tx);
-        if (rho) *rho = range - CLIGHT * clk_tx[0];
-    }
+    if (rho) *rho = range - CLIGHT * clk_sv[0];
 
-    /* LOS range rate with receiver inertial velocity (ECEF):
-       v_rec_inertial = uvel (if provided) + Omega x r_rec */
     if (rdot) {
         double vrx = (uvel ? uvel[0] : 0.0);
         double vry = (uvel ? uvel[1] : 0.0);
         double vrz = (uvel ? uvel[2] : 0.0);
-        /* Omega x r_rec (ECEF), OMEGA_E already defined and used above */
         vrx += -OMEGA_E * u->xyz[1];
         vry +=  OMEGA_E * u->xyz[0];
-        /* vrz += 0 */
-
         double rvx = vel[0] - vrx;
         double rvy = vel[1] - vry;
         double rvz = vel[2] - vrz;
@@ -126,7 +120,7 @@ int select_channels(channel_t *ch,int *n,const coord_t*u,
     }
     *n = m<MAX_CH?m:MAX_CH;
     for(int i=0;i<*n;++i)
-        channel_reset(&ch[i],c[i].prn,u->week,u->sow,c[i].rho);
+        channel_reset(&ch[i],c[i].prn,c[i].rho);
     return *n;
 }
 
@@ -143,6 +137,7 @@ static void update_channels_path(channel_t *ch,int n,
         int prn = ch[i].prn;
         double sat[3], rho, rdot;
         compute_range_rate(prn,u->week,u->sow,u,uvel,sat,&rho,&rdot);
+        channel_set_time(&ch[i], rho, 0);
         double enu[3]; ecef2enu(u,sat,enu);
         double el = enu_elevation_deg(enu);
         update_channel_dynamics(&ch[i],rho,rdot,el,gain,target_cn0,n,step_ms);
@@ -194,6 +189,8 @@ void generate_signal(const sim_config_t *cfg)
     /* 檢查 start 時間是否與星曆 toe 接近 */
     check_ephemeris_age(usr.week, usr.sow);
 
+    g_t_tx = usr.week*604800.0 + usr.sow;
+
     channel_t ch[MAX_CH];
     int n_ch;
     select_channels(ch,&n_ch,&usr,cfg->single_prn,
@@ -228,11 +225,12 @@ void generate_signal(const sim_config_t *cfg)
     const int STEP_MS = cfg->step_ms;
     const uint64_t total_ms=(uint64_t)cfg->duration*1000;
     double start_bdt = usr.week*604800.0 + usr.sow;
+    uint64_t sample_count = 0;
     for(uint64_t ms=0; ms<total_ms; ms+=STEP_MS)
     {
-        double t_abs = start_bdt + ms*0.001;
-        int week = (int)(t_abs/604800.0);
-        double sow = t_abs - week*604800.0;
+        g_t_tx = start_bdt + sample_count/fs;
+        int week = (int)(g_t_tx/604800.0);
+        double sow = g_t_tx - week*604800.0;
 
         double dt = STEP_MS * 0.001;
         double uvel[3], uvel_next[3];
@@ -292,13 +290,13 @@ void generate_signal(const sim_config_t *cfg)
 
         /* --- STEP_MS 次 1ms 取樣 --- */
         for(int step=0;step<STEP_MS;++step){
+            g_t_tx = start_bdt + sample_count/fs;
             memset(accI,0,sizeof(accI)); memset(accQ,0,sizeof(accQ));
 
             /* 併行各通道 */
             #pragma omp parallel for
             for(int c=0;c<n_ch;++c){
-                gen_samples_1ms(&ch[c],week,sow+step*0.001,
-                                samp_per_ms,tmpI[c],tmpQ[c]);
+                gen_samples_1ms(&ch[c],samp_per_ms,tmpI[c],tmpQ[c]);
             }
 
             /* 歸併 */
@@ -331,6 +329,7 @@ void generate_signal(const sim_config_t *cfg)
                     sumI2 += (double)i8[k]*i8[k];
                 }
             }
+            sample_count += samp_per_ms;
             samp_cnt += samp_per_ms;
             if(fp)
                 fwrite(iq,sizeof(int16_t),2*samp_per_ms,fp);

--- a/channel.c
+++ b/channel.c
@@ -3,8 +3,10 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <math.h>
+#include <stdio.h>
 #include "channel.h"
 #include "globals.h"               /* prn_code */
+#include "orbits.h"                /* calc_sat_position_velocity */
 
 #define PI2        6.2831853071795864769
 #define FCARRIER   1561.098e6      /* B1I */
@@ -139,47 +141,81 @@ static void load_ca_once(void)
     ca_ready = 1;
 }
 
-void channel_set_time(channel_t *c,int week,double sow,double rho)
+void channel_set_time(channel_t *c,double rho,int debug)
 {
-    /* Transmission time accounts for signal travel time (rho/c). */
-    double tx_sow = sow - rho/CLIGHT; /* seconds */
-    int tx_week = week;
-    if(tx_sow < 0.0){
-        tx_sow += 604800.0;
-        tx_week -= 1;
-    } else if(tx_sow >= 604800.0){
-        tx_sow -= 604800.0;
-        tx_week += 1;
-    }
-    c->tx_week = tx_week;
+    /* Global transmit time is shared by all channels. */
+    int week = (int)(g_t_tx/604800.0);
+    double sow = g_t_tx - week*604800.0;
+    c->tx_week = week;
+    c->tx_sow  = sow;       /* identical across channels */
+
+    /* Satellite signal left earlier by propagation delay. */
+    double tx_time = g_t_tx - rho/CLIGHT; /* seconds since BDT epoch */
+    int    week_tx = (int)(tx_time/604800.0);
+    double sow_tx  = tx_time - week_tx*604800.0;
 
     /* Compute sub-ms fractional offset to align PRN/NH/data boundaries. */
-    double sow_ms = tx_sow * 1000.0;
+    double sow_ms  = sow_tx * 1000.0;
     double frac_ms = sow_ms - floor(sow_ms);
-    c->code_phase = frac_ms * CODE_LEN;  /* 1 ms = 2046 chips */
+    c->code_phase  = frac_ms * CODE_LEN;  /* 1 ms = 2046 chips */
 
-    double sf_start = floor(tx_sow/6.0)*6.0;
-    c->sf_id = ((int)(sf_start/6.0))%5 + 1;  /* 1..5 */
-    double sub_ms = (tx_sow - sf_start)*1000.0;
-    int ms = (int)floor(sub_ms);
+    /* Navigation subframe alignment (6 s). */
+    double sf_start = floor(sow_tx/6.0)*6.0;
+    if(sf_start != c->nav_sf_start){
+        c->sf_id = ((int)(sf_start/6.0))%5 + 1;  /* 1..5 */
+        get_subframe_bits(c->prn,c->sf_id,week_tx,sf_start,6.0,c->nav_bits);
+        c->nav_sf_start = sf_start;
+    } else {
+        c->sf_id = ((int)(sf_start/6.0))%5 + 1;  /* 1..5 */
+    }
+    int ms = (int)((sow_tx - sf_start)*1000.0);
     if(ms < 0)      ms = 0;
     else if(ms >= 6000) ms = 5999;
     c->bit_ptr = ms/20;
     c->ms_count = ms%20;
 
-    /* ---- D1：以 6 s 對齊作為固定錨點 ---- */
-    c->d1_sf_t0    = sf_start;
-    c->d1_sf_index = 0;
-    get_subframe_bits(c->prn,c->sf_id,c->tx_week,c->d1_sf_t0,6.0,c->nav_bits);
     if(ms == 0 && frac_ms < 1e-9){
-        /* 在子幀邊界，強制對齊三個時序：PRN、NH20、NAV */
-        c->code_phase = 0.0;     /* 1 ms PRN 2046 chips 從頭開始 */
-        c->ms_count   = 0;       /* NH20 index 從 0 開始 */
-        c->bit_ptr    = 0;       /* 50 bps NAV bit 從 0 開始 */
+        /* At subframe boundary, force perfect alignment of PRN/NH/NAV. */
+        c->code_phase = 0.0;
+        c->ms_count   = 0;
+        c->bit_ptr    = 0;
+    }
+
+    if(debug){
+        uint32_t sow_int = (uint32_t)sf_start; /* SOW integer used in navbits */
+        const ephemeris_t *ep = &eph[c->prn];
+        /* Extract word3 bits (30 bits with parity) from cached nav bits */
+        uint32_t word3 = 0;
+        for(int i=60;i<90;++i)
+            word3 = (word3<<1) | c->nav_bits[i];
+
+        double t_tx  = g_t_tx; /* global transmit time */
+        double t_toe = ep->week*604800.0 + ep->toe;
+        double t_toc = ep->week*604800.0 + ep->toc;
+        double dt_toe = t_tx - t_toe;
+        double dt_toc = t_tx - t_toc;
+        double clk_bias_ns = 0.0;
+        double clk[2], pos_dummy[3], vel_dummy[3];
+        calc_sat_position_velocity(c->prn, week, sow,
+                                   pos_dummy, vel_dummy, clk);
+        clk_bias_ns = clk[0]*1e9; /* seconds to ns */
+
+        static int printed_global = 0;
+        if(!printed_global){
+            printf("Global: tx_week %d tx_sow %.6f\n", week, sow);
+            printed_global = 1;
+        }
+
+        printf("PRN %02d: tx_sow %.6f sow_int %u word3_TOW 0x%08X "
+               "dToE %.3f dToC %.3f clock_bias %.3f ns code_phase %.0f "
+               "NH %u bit %u\n",
+               c->prn, sow, sow_int, word3,
+               dt_toe, dt_toc, clk_bias_ns,
+               floor(c->code_phase), c->ms_count, c->bit_ptr);
     }
 }
 
-void channel_reset(channel_t *c,int prn,int week,double sow,double rho){
+void channel_reset(channel_t *c,int prn,double rho){
     memset(c,0,sizeof(*c));
     c->prn   = prn;
     load_ca_once();
@@ -187,7 +223,7 @@ void channel_reset(channel_t *c,int prn,int week,double sow,double rho){
     /* Randomise starting carrier phase so I/Q averages are balanced. */
     c->carr_phase = ((double)rand()/(double)RAND_MAX)*PI2;
 
-    channel_set_time(c,week,sow,rho);
+    channel_set_time(c,rho,1);
 }
 /* 幾何→計算振幅 / 初始多普勒 */
 void update_channel_dynamics(channel_t *c,double rho,double rdot,double elev_deg,
@@ -209,16 +245,8 @@ void channel_set_fs(double sample_rate)
 }
 
 /* ---------- 產生 1 ms ---------- */
-void gen_samples_1ms(channel_t *c,int week,double sow,
-                     int samp_per_ms,int16_t*I,int16_t*Q)
+void gen_samples_1ms(channel_t *c,int samp_per_ms,int16_t*I,int16_t*Q)
 {
-    (void)week; (void)sow;
-    if(c->bit_ptr==0 && c->ms_count==0){
-        /* 一律使用固定錨點 + 6.0 * index，杜絕邊界抖動 */
-        double t0 = c->d1_sf_t0 + 6.0 * c->d1_sf_index;
-        get_subframe_bits(c->prn,c->sf_id,c->tx_week,t0,6.0,c->nav_bits);
-    }
-
     double fd = c->fd;
     double code_rate = c->code_rate;
     double phase = c->carr_phase;
@@ -252,7 +280,6 @@ void gen_samples_1ms(channel_t *c,int week,double sow,
                 if(++c->bit_ptr==300){
                     c->bit_ptr=0;
                     c->sf_id=c->sf_id%5+1;      /* 1..5 */
-                    c->d1_sf_index=(c->d1_sf_index+1)%5;
                 }
             }
         }

--- a/channel.h
+++ b/channel.h
@@ -23,23 +23,21 @@ typedef struct {
     uint8_t  ms_count;      /* 0~19: ms index within data bit */
     uint8_t  nav_bits[300]; /* cached subframe bits */
 
-    int     tx_week;       /* transmission week number */
+    int     tx_week;       /* global transmission week number */
+    double  tx_sow;        /* global transmission seconds-of-week */
 
-    /* ---- D1 固定時間錨點（6 s 子幀） ---- */
-    double  d1_sf_t0;       /* 第一次對齊好的 D1 子幀起點（周內秒） */
-    int     d1_sf_index;    /* 子幀索引 0..4（每 6 s 前進一次，對應頁 1..5） */
+    double  nav_sf_start;   /* start SOW of current 6 s subframe */
 
 } channel_t;
 
-void channel_reset(channel_t *, int prn, int week, double sow, double rho);
-void channel_set_time(channel_t *, int week, double sow, double rho);
+void channel_reset(channel_t *, int prn, double rho);
+void channel_set_time(channel_t *, double rho, int debug);
 void update_channel_dynamics(channel_t *, double rho, double rdot,
                              double elev_deg, double gain,
                              double target_cn0, int n_visible,
                              double dt_ms);
 void channel_set_fs(double sample_rate);
-void gen_samples_1ms(channel_t *, int week, double sow,
-                     int samp_per_ms, int16_t *I, int16_t *Q);
+void gen_samples_1ms(channel_t *, int samp_per_ms, int16_t *I, int16_t *Q);
 int  is_geo_prn(int prn);
 int  is_igso_prn(int prn);
 int  is_meo_prn(int prn);

--- a/globals.c
+++ b/globals.c
@@ -23,6 +23,9 @@ int    utc_bdt_diff  = 4;   /* default UTC->BDT offset */
 int simulator_inited = 0;
 int prn_max = 63;
 
+/* Global transmit time (BDT seconds) */
+double g_t_tx = 0.0;
+
 /* ───────────── B1I PRN 產生 ───────────── */
 #define ITER 2047                     /* 先跑滿 2047，再丟掉最後 1 chip */
 

--- a/globals.h
+++ b/globals.h
@@ -27,5 +27,8 @@ extern double       iono_alpha[4];  /* ionospheric parameters */
 extern double       iono_beta[4];
 extern int          utc_bdt_diff;   /* UTC->BDT offset seconds */
 
+/* Global transmit time in BDT seconds */
+extern double       g_t_tx;
+
 #endif
 

--- a/main.c
+++ b/main.c
@@ -220,6 +220,7 @@ int main(int argc,char *argv[])
     }
     usr.week = start_week;
     usr.sow  = start_sow;
+    g_t_tx   = start_bdt; /* initialize global transmit time */
 
     coord_t ref_llh = usr;
     static_user_at(usr.week, usr.sow, &ref_llh, &usr, NULL);

--- a/tests/test_nh_prn.c
+++ b/tests/test_nh_prn.c
@@ -23,7 +23,8 @@ int main(void)
 
     int prn = 8; /* MEO/IGSO uses D1 with NH code */
     channel_t ch;
-    channel_reset(&ch, prn, nav_week, 0.0, 0.0);
+    g_t_tx = nav_week*604800.0;
+    channel_reset(&ch, prn, 0.0);
     ch.carr_phase = 0.0;
     ch.code_phase = 0.1; /* avoid boundary ambiguity */
     update_channel_dynamics(&ch, 2.0e7, 0.0, 90.0, 1.0, cfg.target_cn0, 1, 1.0);
@@ -35,7 +36,7 @@ int main(void)
     /* generate 20 ms and verify NH/PRN relationship */
     int base_sign = 0;
     for(int i=0;i<20;i++){
-        gen_samples_1ms(&ch, nav_week, i*0.001, samp_per_ms, I, Q);
+        gen_samples_1ms(&ch, samp_per_ms, I, Q);
         int sign = (I[0] >= 0) ? 1 : -1;
         if(i==0){
             base_sign = sign;               /* nav bit sign */


### PR DESCRIPTION
## Summary
- Derive global transmit time from sample count so all modules share one BDT timeline
- Recompute each channel's code/NH/navigation timing from the global transmit time before dynamics
- Log nav frame word 3 bits during channel initialization
- Ensure per-channel `tx_sow` mirrors the shared global time instead of pseudorange-adjusted values

## Testing
- `make -s check`
- `./bds-sim --rinex BRDM00DLR_S_20251760000_01D_MN.rnx --start 2025/06/25,00:00:00 --duration 1 --gain 1.0 --llh 24,121,0`
- `./bds-sim --rinex BRDM00DLR_S_20251760000_01D_MN.rnx --start 2025/06/25,12:00:00 --duration 1 --gain 1.0 --llh 24,121,0`


------
https://chatgpt.com/codex/tasks/task_e_68a5e59d63948327a07bd464b43821bc