### PR TITLE
Refactor timing and coordinate handling

### DIFF
--- a/bdssim.c
+++ b/bdssim.c
@@ -47,72 +47,46 @@ static void check_ephemeris_age(int week,double sow)
         fputs("建議使用接近星曆 toe 的起始時間以避免 tk 錯誤\n", stderr);
 }
 
-/* Compute corrected pseudorange and range rate */
-static void compute_range_rate(int prn,int week,double sow,
-                               const coord_t *u,const double uvel[3],
-                               double sat[3],double *rho,double *rdot)
+/* Compute pseudorange and satellite position in ECEF */
+static double compute_pseudorange(int prn,int week,double sow,
+                                  const coord_t *u,double sat[3])
 {
-    /* Satellite clock at global transmit time */
-    double clk_tx[2], pos_dummy[3], vel_dummy[3];
-    calc_sat_position_velocity(prn, week, sow, pos_dummy, vel_dummy, clk_tx);
+    double clk_tx[2], dummy[3];
+    calc_sat_position_velocity(prn, week, sow, dummy, NULL, clk_tx);
     double t_sv = week*604800.0 + sow - clk_tx[0];
     int week_sv = (int)(t_sv/604800.0);
     double sow_sv = t_sv - week_sv*604800.0;
 
-    double pos[3], vel[3], clk_sv[2];
-    calc_sat_position_velocity(prn, week_sv, sow_sv, pos, vel, clk_sv);
+    double eci[3];
+    calc_sat_position_velocity(prn, week_sv, sow_sv, eci, NULL, NULL);
+    double ecef[3];
+    eci_to_ecef(eci, week_sv, sow_sv, ecef);
+    if(sat){ sat[0]=ecef[0]; sat[1]=ecef[1]; sat[2]=ecef[2]; }
 
-    double dx = pos[0]-u->xyz[0];
-    double dy = pos[1]-u->xyz[1];
-    double dz = pos[2]-u->xyz[2];
-    double range = hypot(hypot(dx,dy),dz);
-    double tau = range / CLIGHT;
-
-    /* Earth rotation during signal travel */
-    double xrot = pos[0] + pos[1]*OMEGA_E*tau;
-    double yrot = pos[1] - pos[0]*OMEGA_E*tau;
-    pos[0] = xrot;
-    pos[1] = yrot;
-
-    if(sat){ sat[0]=pos[0]; sat[1]=pos[1]; sat[2]=pos[2]; }
-
-    dx = pos[0]-u->xyz[0];
-    dy = pos[1]-u->xyz[1];
-    dz = pos[2]-u->xyz[2];
-    range = hypot(hypot(dx,dy),dz);
-
-    if (rho) *rho = range - CLIGHT * clk_sv[0];
-
-    if (rdot) {
-        double vrx = (uvel ? uvel[0] : 0.0);
-        double vry = (uvel ? uvel[1] : 0.0);
-        double vrz = (uvel ? uvel[2] : 0.0);
-        vrx += -OMEGA_E * u->xyz[1];
-        vry +=  OMEGA_E * u->xyz[0];
-        double rvx = vel[0] - vrx;
-        double rvy = vel[1] - vry;
-        double rvz = vel[2] - vrz;
-        *rdot = (rvx*dx + rvy*dy + rvz*dz) / range;  /* m/s */
-    }
+    double dx = ecef[0]-u->xyz[0];
+    double dy = ecef[1]-u->xyz[1];
+    double dz = ecef[2]-u->xyz[2];
+    double rho_geom = hypot(hypot(dx,dy),dz);
+    double sag = OMEGA_E/CLIGHT * (ecef[0]*u->xyz[1] - ecef[1]*u->xyz[0]);
+    return rho_geom + sag - CLIGHT * clk_tx[0];
 }
 
 /*----------------------------------------------------*/
 int select_channels(channel_t *ch,int *n,const coord_t*u,
                     int single_prn,bool meo_only)
 {
-    struct cand{int prn;double elev,rho,rdot;} c[63];
+    struct cand{int prn;double elev,rho;} c[63];
     int m=0;
     for(int prn=1;prn<=prn_max;++prn){
         if(single_prn>0 && prn!=single_prn) continue;
         if(is_geo_prn(prn)) continue;
         if(meo_only && !is_meo_prn(prn)) continue;
-        double sat[3], rho, rdot;
-        compute_range_rate(prn,u->week,u->sow,u,NULL,sat,&rho,&rdot);
+        double sat[3];
+        double rho0 = compute_pseudorange(prn,u->week,u->sow,u,sat);
         double enu[3]; ecef2enu(u,sat,enu);
-        double el=enu_elevation_deg(enu); if(el<5.0)continue;
-        c[m++] = (struct cand){prn,el,rho,rdot};
+        double el = enu_elevation_deg(enu); if(el<5.0) continue;
+        c[m++] = (struct cand){prn,el,rho0};
     }
-    /* sort by elevation (desc) */
     for(int i=0;i<m-1;++i) for(int j=i+1;j<m;++j){
         if(c[j].elev>c[i].elev){
             struct cand t=c[i];c[i]=c[j];c[j]=t;
@@ -127,34 +101,43 @@ int select_channels(channel_t *ch,int *n,const coord_t*u,
 
 /* 依照使用者軌跡更新通道，使用目前與下一步的幾何資訊 */
 static void update_channels_path(channel_t *ch,int n,
-                                 const coord_t *u,const double uvel[3],
-                                 const coord_t *u_next,const double uvel_next[3],
+                                 const coord_t *u,
+                                 const coord_t *u_next,
+                                 const coord_t *u_next2,
                                  double gain,double target_cn0,int step_ms)
 {
     double dt = step_ms * 0.001; /* seconds */
 
     for(int i=0;i<n;++i){
         int prn = ch[i].prn;
-        double sat[3], rho, rdot;
-        compute_range_rate(prn,u->week,u->sow,u,uvel,sat,&rho,&rdot);
-        channel_set_time(&ch[i], rho, 0);
-        double enu[3]; ecef2enu(u,sat,enu);
-        double el = enu_elevation_deg(enu);
-        update_channel_dynamics(&ch[i],rho,rdot,el,gain,target_cn0,n,step_ms);
-        if(el < 5.0) ch[i].amp = 0.0;     /* below horizon → mute */
 
-        /* predict next dynamics using next position/velocity */
-        double t_abs = u->week*604800.0 + u->sow + dt;
-        int week2 = (int)(t_abs/604800.0);
-        double sow2 = t_abs - week2*604800.0;
-        double sat2[3], rho2, rdot2;
-        compute_range_rate(prn,week2,sow2,u_next,uvel_next,sat2,&rho2,&rdot2);
-        double enu2[3]; ecef2enu(u_next,sat2,enu2);
-        double el2 = enu_elevation_deg(enu2);
-        double fd2 = -FCARRIER*rdot2/CLIGHT;
-        double cr2 = CHIPRATE*(1.0 - rdot2/CLIGHT);
-        double A2 = predict_next_amp(&ch[i], rho2, el2, gain, target_cn0, n, step_ms);
-        if(el2 < 5.0) A2 = 0.0;
+        double sat0[3];
+        double rho0 = compute_pseudorange(prn, u->week, u->sow, u, sat0);
+
+        double t1_abs = u->week*604800.0 + u->sow + dt;
+        int week1 = (int)(t1_abs/604800.0);
+        double sow1 = t1_abs - week1*604800.0;
+        double sat1[3];
+        double rho1 = compute_pseudorange(prn, week1, sow1, u_next, sat1);
+
+        double rdot = (rho1 - rho0) / dt;
+        channel_set_time(&ch[i], rho0, 0);
+        double enu0[3]; ecef2enu(u, sat0, enu0);
+        double el0 = enu_elevation_deg(enu0);
+        update_channel_dynamics(&ch[i], rho0, rdot, el0, gain, target_cn0, n, step_ms);
+        if(el0 < 5.0) ch[i].amp = 0.0;
+
+        double t2_abs = t1_abs + dt;
+        int week2 = (int)(t2_abs/604800.0);
+        double sow2 = t2_abs - week2*604800.0;
+        double rho2 = compute_pseudorange(prn, week2, sow2, u_next2, NULL);
+        double rdot2 = (rho2 - rho1) / dt;
+        double enu1[3]; ecef2enu(u_next, sat1, enu1);
+        double el1 = enu_elevation_deg(enu1);
+        double fd2 = -FCARRIER * rdot2 / CLIGHT;
+        double cr2 = CHIPRATE * (1.0 - rdot2 / CLIGHT);
+        double A2 = predict_next_amp(&ch[i], rho1, el1, gain, target_cn0, n, step_ms);
+        if(el1 < 5.0) A2 = 0.0;
         ch[i].fd_dot = (fd2 - ch[i].fd) / dt;
         ch[i].code_rate_dot = (cr2 - ch[i].code_rate) / dt;
         ch[i].amp_dot = (A2 - ch[i].amp) / dt;
@@ -182,9 +165,6 @@ void generate_signal(const sim_config_t *cfg)
         free_path(&path);
         return;
     }
-
-    coord_t ref_llh=usr;              /* 保存經緯度作旋轉基準 */
-    static_user_at(usr.week,usr.sow,&ref_llh,&usr,NULL);
 
     /* 檢查 start 時間是否與星曆 toe 接近 */
     check_ephemeris_age(usr.week, usr.sow);
@@ -233,16 +213,15 @@ void generate_signal(const sim_config_t *cfg)
         double sow = g_t_tx - week*604800.0;
 
         double dt = STEP_MS * 0.001;
-        double uvel[3], uvel_next[3];
-        coord_t usr_next={0};
+        coord_t usr_next={0}, usr2={0};
         if(cfg->path_type==0){
             usr.week = week;
             usr.sow  = sow;
             usr_next = usr;
             usr_next.sow = sow + dt;
-            uvel[0]=uvel[1]=uvel[2]=0.0;
-            uvel_next[0]=uvel_next[1]=uvel_next[2]=0.0;
-            update_channels_path(ch,n_ch,&usr,uvel,&usr_next,uvel_next,
+            usr2 = usr;
+            usr2.sow = sow + 2*dt;
+            update_channels_path(ch,n_ch,&usr,&usr_next,&usr2,
                                  cfg->gain,g_target_cn0,STEP_MS);
         } else if(cfg->path_type==1){
             coord_t u0,u1,u2;
@@ -250,35 +229,19 @@ void generate_signal(const sim_config_t *cfg)
             interpolate_path(&path, (ms+STEP_MS)/1000.0, &u1);
             interpolate_path(&path, (ms+2*STEP_MS)/1000.0, &u2);
             xyz2llh(u0.xyz,&usr); usr.week=week; usr.sow=sow;
-            xyz2llh(u1.xyz,&usr_next);
-            xyz2llh(u2.xyz,&u2);
-            uvel[0]=(u1.xyz[0]-u0.xyz[0])/dt;
-            uvel[1]=(u1.xyz[1]-u0.xyz[1])/dt;
-            uvel[2]=(u1.xyz[2]-u0.xyz[2])/dt;
-            uvel_next[0]=(u2.xyz[0]-u1.xyz[0])/dt;
-            uvel_next[1]=(u2.xyz[1]-u1.xyz[1])/dt;
-            uvel_next[2]=(u2.xyz[2]-u1.xyz[2])/dt;
-            update_channels_path(ch,n_ch,&usr,uvel,&usr_next,uvel_next,
+            xyz2llh(u1.xyz,&usr_next); usr_next.week=week; usr_next.sow=sow+dt;
+            xyz2llh(u2.xyz,&usr2); usr2.week=week; usr2.sow=sow+2*dt;
+            update_channels_path(ch,n_ch,&usr,&usr_next,&usr2,
                                  cfg->gain,g_target_cn0,STEP_MS);
         } else {
             double llh0[3], llh1[3], llh2[3];
             interpolate_path_llh(&path, ms/1000.0, llh0);
             interpolate_path_llh(&path, (ms+STEP_MS)/1000.0, llh1);
             interpolate_path_llh(&path, (ms+2*STEP_MS)/1000.0, llh2);
-            coord_t ref0={0}, ref1={0}, ref2={0};
-            ref0.llh[0]=llh0[0]; ref0.llh[1]=llh0[1]; ref0.llh[2]=llh0[2];
-            ref1.llh[0]=llh1[0]; ref1.llh[1]=llh1[1]; ref1.llh[2]=llh1[2];
-            ref2.llh[0]=llh2[0]; ref2.llh[1]=llh2[1]; ref2.llh[2]=llh2[2];
-            static_user_at(week,sow,&ref0,&usr,NULL);
-            static_user_at(week,sow+dt,&ref1,&usr_next,NULL);
-            coord_t usr2; static_user_at(week,sow+2*dt,&ref2,&usr2,NULL);
-            uvel[0]=(usr_next.xyz[0]-usr.xyz[0])/dt;
-            uvel[1]=(usr_next.xyz[1]-usr.xyz[1])/dt;
-            uvel[2]=(usr_next.xyz[2]-usr.xyz[2])/dt;
-            uvel_next[0]=(usr2.xyz[0]-usr_next.xyz[0])/dt;
-            uvel_next[1]=(usr2.xyz[1]-usr_next.xyz[1])/dt;
-            uvel_next[2]=(usr2.xyz[2]-usr_next.xyz[2])/dt;
-            update_channels_path(ch,n_ch,&usr,uvel,&usr_next,uvel_next,
+            llh2xyz(llh0,&usr); usr.week=week; usr.sow=sow;
+            llh2xyz(llh1,&usr_next); usr_next.week=week; usr_next.sow=sow+dt;
+            llh2xyz(llh2,&usr2); usr2.week=week; usr2.sow=sow+2*dt;
+            update_channels_path(ch,n_ch,&usr,&usr_next,&usr2,
                                  cfg->gain,g_target_cn0,STEP_MS);
         }
         if(ms==0){

--- a/coord.c
+++ b/coord.c
@@ -82,31 +82,15 @@ void ecef_to_eci(const double ecef[3],int week,double sow,double eci[3])
     eci[2] = ecef[2];
 }
 
-/* Rotate fixed LLH with Earth rotation ------------------------------- */
-void static_user_at(int week,double sow,const coord_t *ref,
-                    coord_t *out,double vel[3])
+/* ECI → ECEF -------------------------------------------------------- */
+void eci_to_ecef(const double eci[3],int week,double sow,double ecef[3])
 {
-    double lat = ref->llh[0]*(M_PI/180.0);
-    double lon0= ref->llh[1]*(M_PI/180.0);
-    double h   = ref->llh[2];
-    double sinp= sin(lat); double cosp=cos(lat);
-    double N   = WGS_A/sqrt(1.0-WGS_E2*sinp*sinp);
-    double t   = (week-nav_week)*604800.0 + sow;
-    double lon = lon0 + OMEGA_E*t;
-    double cosL= cos(lon), sinL= sin(lon);
-    out->xyz[0]=(N+h)*cosp*cosL;
-    out->xyz[1]=(N+h)*cosp*sinL;
-    out->xyz[2]=(N*(1.0-WGS_E2)+h)*sinp;
-    out->llh[0]=ref->llh[0];
-    out->llh[1]=ref->llh[1];
-    out->llh[2]=ref->llh[2];
-    out->week=week;
-    out->sow=sow;
-    if(vel){
-        vel[0]=-OMEGA_E*out->xyz[1];
-        vel[1]= OMEGA_E*out->xyz[0];
-        vel[2]=0.0;
-    }
+    double t = (week - nav_week)*604800.0 + sow;
+    double theta = OMEGA_E * t;
+    double cosT = cos(theta), sinT = sin(theta);
+    ecef[0] = cosT*eci[0] + sinT*eci[1];
+    ecef[1] = -sinT*eci[0] + cosT*eci[1];
+    ecef[2] = eci[2];
 }
 
 

--- a/coord.h
+++ b/coord.h
@@ -20,7 +20,7 @@ void   xyz2llh(const double xyz[3], coord_t *c);
 void   ecef2enu(const coord_t *usr, const double sat_xyz[3], double enu[3]);
 double enu_elevation_deg(const double enu[3]);
 void   ecef_to_eci(const double ecef[3],int week,double sow,double eci[3]);
-void   static_user_at(int week,double sow,const coord_t *ref,coord_t *out,double vel[3]);
+void   eci_to_ecef(const double eci[3],int week,double sow,double ecef[3]);
 
 #endif
 

--- a/main.c
+++ b/main.c
@@ -222,9 +222,6 @@ int main(int argc,char *argv[])
     usr.sow  = start_sow;
     g_t_tx   = start_bdt; /* initialize global transmit time */
 
-    coord_t ref_llh = usr;
-    static_user_at(usr.week, usr.sow, &ref_llh, &usr, NULL);
-
     channel_t ch[MAX_CH];
     int n_ch;
     select_channels(ch,&n_ch,&usr,cfg.single_prn,

--- a/orbits.c
+++ b/orbits.c
@@ -70,10 +70,11 @@ void calc_sat_position_velocity(int prn, int week, double sow,
     const double x_op = r * cos(u);
     const double y_op = r * sin(u);
 
-    /* -------- RAAN Ω(t) -------------------------------------- */
-    /* Use unified RAAN expression for all BeiDou satellites
-     * Ω(t) = Ω₀ + (Ω̇ − Ωₑ) · tk − Ωₑ · Toe */
-    double Omega = ep->omega0 + (ep->omegadot - OMEGA_E) * tk - OMEGA_E * ep->toe;
+    /* -------- RAAN Ω(t) (inertial frame) ---------------------- */
+    /* Compute the right ascension of the ascending node in the
+     * Earth-centered inertial frame. Earth rotation is applied
+     * later when converting to ECEF. */
+    double Omega = ep->omega0 + ep->omegadot * tk;
 
     /* -------- ECI (WGS-84 inertial) 座標 ----------------------- */
     const double cosO = cos(Omega), sinO = sin(Omega);
@@ -97,8 +98,8 @@ void calc_sat_position_velocity(int prn, int week, double sow,
         const double i_dot   = ep->idot + 2 * (ep->cis * cos(2 * phi)
                                              - ep->cic * sin(2 * phi)) * phi_dot;
 
-        /* dΩ/dt = Ω̇ − Ωₑ for all BeiDou satellites */
-        const double Omega_dot = ep->omegadot - OMEGA_E;
+        /* dΩ/dt in the inertial frame */
+        const double Omega_dot = ep->omegadot;
 
         const double x_op_dot = r_dot * cos(u) - r * u_dot * sin(u);
         const double y_op_dot = r_dot * sin(u) + r * u_dot * cos(u);

--- a/tests/test_orbits.c
+++ b/tests/test_orbits.c
@@ -5,6 +5,7 @@
 #include "../globals.h"
 #include "../orbits.h"
 #include "../timeconv.h"
+#include "../coord.h"
 
 
 int main(void)
@@ -77,20 +78,27 @@ int main(void)
             continue;            /* skip header before first epoch */
 
         if(l[0]=='P' && l[1]=='C'){
-            int prn; double x,y,z,clk;
-            if(sscanf(l+1, "C%2d %lf %lf %lf %lf", &prn,&x,&y,&z,&clk)!=5) continue;
+              int prn; double x,y,z,clk_sp3;
+              if(sscanf(l+1, "C%2d %lf %lf %lf %lf", &prn,&x,&y,&z,&clk_sp3)!=5) continue;
             if(prn<1 || prn>63 || eph[prn].prn==0) continue;
             if(prn <= 5 || (prn >= 59 && prn <= 63))
                 continue;        /* skip GEO satellites */
 
-            double xyz[3];
-            calc_sat_position_velocity(prn, bw, bsow, xyz, NULL, NULL);
+              double clk_sv[2], dummy[3];
+              calc_sat_position_velocity(prn, bw, bsow, dummy, NULL, clk_sv);
+              double t_sv = bw*604800.0 + bsow - clk_sv[0];
+              int w_sv = (int)(t_sv/604800.0);
+              double sow_sv = t_sv - w_sv*604800.0;
+              double eci[3];
+              calc_sat_position_velocity(prn, w_sv, sow_sv, eci, NULL, NULL);
+              double ecef[3];
+              eci_to_ecef(eci, w_sv, sow_sv, ecef);
 
-            printf("time=%s PRN%02d calc=(%.3f %.3f %.3f) sp3=(%.3f %.3f %.3f)\n",
-                   current_utc, prn, xyz[0], xyz[1], xyz[2],
-                   x*1000.0, y*1000.0, z*1000.0);
-        }
-    }
+              printf("time=%s PRN%02d calc=(%.3f %.3f %.3f) sp3=(%.3f %.3f %.3f)\n",
+                     current_utc, prn, ecef[0], ecef[1], ecef[2],
+                     x*1000.0, y*1000.0, z*1000.0);
+          }
+      }
     fclose(fp);
 
     return 0;


### PR DESCRIPTION
## Summary
- compute satellite orbits in ECI and rotate once to ECEF at transmit time
- derive pseudorange with Sagnac correction and numeric Doppler/code rate
- remove receiver Earth-rotation velocity and simplify coordinate utilities

## Testing
- `make check`
- `make tests/test_orbits && ./tests/test_orbits | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_68a6bba970dc8327ba65c25459660f5b