### PR TITLE
Unify ECEF handling and add range-rate sanity checks

### DIFF
--- a/bdssim.c
+++ b/bdssim.c
@@ -15,9 +15,8 @@
 #include "globals.h"     /* nav_week, CLIGHT */
 #define FSAMP_DEF FS_OUTPUT_HZ    /* default 6.144 MHz for 16-bit I/Q output */
 #define FSAMP_BYTE 25.0e6    /* 25 MHz when --byte is used */
-#define FCARRIER   1561.098e6      /* B1I carrier */
+#define F_B1I      1561.098e6      /* B1I carrier */
 #define CHIPRATE   2.046e6
-#define OMEGA_E    7.2921150e-5
 
 /* ========= 振幅計算與 int16 飽和保護 ========= */
 static inline int16_t saturate_int16(double x)
@@ -50,69 +49,77 @@ static void check_ephemeris_age(int week,double sow)
 /* Compute corrected pseudorange and range rate */
 static void compute_range_rate(int prn,int week,double sow,
                                const coord_t *u,const double uvel[3],
-                               double sat[3],double *rho,double *rdot)
+                               double sat_rx[3], double vsat_rx[3],
+                               double *rho,double *rdot,double los[3])
 {
     /* Receiver time in seconds since BDT epoch */
     double t_rx = week*604800.0 + sow;
 
-    /* First, get satellite clock at receiver time */
+    /* Satellite clock at receiver time for initial guess */
     double clk_rx[2], pos_dummy[3], vel_dummy[3];
     calc_sat_position_velocity(prn, week, sow, pos_dummy, vel_dummy, clk_rx);
 
-    /* Initial transmit time estimate (no range yet) */
+    /* Initial transmit time estimate */
     double t_tx = t_rx - clk_rx[0];
 
-    /* Compute satellite position/clock at this estimate */
+    /* Iterate once with geometric range */
     int week_sv = (int)(t_tx/604800.0);
     double sow_sv = t_tx - week_sv*604800.0;
-    double pos[3], vel[3], clk_sv[2];
-    calc_sat_position_velocity(prn, week_sv, sow_sv, pos, vel, clk_sv);
-
-    /* Rough geometric range to estimate signal flight time */
-    double dx = pos[0]-u->xyz[0];
-    double dy = pos[1]-u->xyz[1];
-    double dz = pos[2]-u->xyz[2];
+    double r_tx[3], v_tx[3], clk_sv[2];
+    calc_sat_position_velocity(prn, week_sv, sow_sv, r_tx, v_tx, clk_sv);
+    double dx = r_tx[0] - u->xyz[0];
+    double dy = r_tx[1] - u->xyz[1];
+    double dz = r_tx[2] - u->xyz[2];
     double range = hypot(hypot(dx,dy),dz);
     double tau = range / CLIGHT;
 
-    /* Refine transmit time with flight time and updated clock */
+    /* Refined transmit time */
     t_tx = t_rx - tau - clk_sv[0];
     week_sv = (int)(t_tx/604800.0);
     sow_sv  = t_tx - week_sv*604800.0;
-    calc_sat_position_velocity(prn, week_sv, sow_sv, pos, vel, clk_sv);
+    calc_sat_position_velocity(prn, week_sv, sow_sv, r_tx, v_tx, clk_sv);
 
-    /* Recompute range and signal travel time */
-    dx = pos[0]-u->xyz[0];
-    dy = pos[1]-u->xyz[1];
-    dz = pos[2]-u->xyz[2];
+    /* Time difference between tx and rx */
+    tau = t_rx - t_tx;
+
+    /* Rotate satellite state to receiver time */
+    double A = OMEGA_E * tau;
+    double cA = cos(A), sA = sin(A);
+    double x_rx =  cA*r_tx[0] + sA*r_tx[1];
+    double y_rx = -sA*r_tx[0] + cA*r_tx[1];
+    double z_rx =  r_tx[2];
+
+    double vx_rot =  cA*v_tx[0] + sA*v_tx[1];
+    double vy_rot = -sA*v_tx[0] + cA*v_tx[1];
+    double vz_rot =  v_tx[2];
+
+    double vx_rx = vx_rot + (sA*OMEGA_E)*r_tx[0] + (-cA*OMEGA_E)*r_tx[1];
+    double vy_rx = vy_rot + (cA*OMEGA_E)*r_tx[0] + ( sA*OMEGA_E)*r_tx[1];
+    double vz_rx = vz_rot;
+
+    if(sat_rx){ sat_rx[0]=x_rx; sat_rx[1]=y_rx; sat_rx[2]=z_rx; }
+    if(vsat_rx){ vsat_rx[0]=vx_rx; vsat_rx[1]=vy_rx; vsat_rx[2]=vz_rx; }
+
+    dx = x_rx - u->xyz[0];
+    dy = y_rx - u->xyz[1];
+    dz = z_rx - u->xyz[2];
     range = hypot(hypot(dx,dy),dz);
-    tau = range / CLIGHT;
 
-    /* Earth rotation during signal travel */
-    double xrot = pos[0] + pos[1]*OMEGA_E*tau;
-    double yrot = pos[1] - pos[0]*OMEGA_E*tau;
-    pos[0] = xrot;
-    pos[1] = yrot;
-
-    if(sat){ sat[0]=pos[0]; sat[1]=pos[1]; sat[2]=pos[2]; }
-
-    dx = pos[0]-u->xyz[0];
-    dy = pos[1]-u->xyz[1];
-    dz = pos[2]-u->xyz[2];
-    range = hypot(hypot(dx,dy),dz);
+    double ex = dx / range;
+    double ey = dy / range;
+    double ez = dz / range;
+    if(los){ los[0]=ex; los[1]=ey; los[2]=ez; }
 
     if (rho) *rho = range - CLIGHT * clk_sv[0];
 
     if (rdot) {
-        double vrx = (uvel ? uvel[0] : 0.0);
-        double vry = (uvel ? uvel[1] : 0.0);
-        double vrz = (uvel ? uvel[2] : 0.0);
-        vrx += -OMEGA_E * u->xyz[1];
-        vry +=  OMEGA_E * u->xyz[0];
-        double rvx = vel[0] - vrx;
-        double rvy = vel[1] - vry;
-        double rvz = vel[2] - vrz;
-        *rdot = (rvx*dx + rvy*dy + rvz*dz) / range;  /* m/s */
+        double vrx = uvel ? uvel[0] : 0.0;
+        double vry = uvel ? uvel[1] : 0.0;
+        double vrz = uvel ? uvel[2] : 0.0;
+        double dvx = vx_rx - vrx;
+        double dvy = vy_rx - vry;
+        double dvz = vz_rx - vrz;
+        *rdot = ex*dvx + ey*dvy + ez*dvz;  /* m/s */
     }
 }
 
@@ -127,8 +134,8 @@ int select_channels(channel_t *ch,int *n,const coord_t*u,
         if(is_geo_prn(prn)) continue;
         if(meo_only && !is_meo_prn(prn)) continue;
         double sat[3], rho, rdot;
-        compute_range_rate(prn,u->week,u->sow,u,NULL,sat,&rho,&rdot);
-        double enu[3]; ecef2enu(u,sat,enu);
+        compute_range_rate(prn,u->week,u->sow,u,NULL,sat,NULL,&rho,&rdot,NULL);
+        double enu[3]; ecef_to_enu(u,sat,enu);
         double el=enu_elevation_deg(enu); if(el<5.0)continue;
         c[m++] = (struct cand){prn,el,rho,rdot};
     }
@@ -153,14 +160,30 @@ static void update_channels_path(channel_t *ch,int n,
 {
     double dt = step_ms * 0.001; /* seconds */
 
+    double t_abs = u->week*604800.0 + u->sow;
+    static int last_sec = -1;
+    int cur_sec = (int)t_abs;
+    int print_now = 0;
+    if(cur_sec != last_sec){
+        last_sec = cur_sec;
+        print_now = 1;
+    }
+
     for(int i=0;i<n;++i){
         int prn = ch[i].prn;
         double sat[3], rho, rdot;
-        compute_range_rate(prn,u->week,u->sow,u,uvel,sat,&rho,&rdot);
+        double vsat[3], los[3];
+        compute_range_rate(prn,u->week,u->sow,u,uvel,sat,vsat,&rho,&rdot,los);
         channel_set_time(&ch[i], rho, 0);
-        double enu[3]; ecef2enu(u,sat,enu);
+        double enu[3]; ecef_to_enu(u,sat,enu);
         double el = enu_elevation_deg(enu);
         update_channel_dynamics(&ch[i],rho,rdot,el,gain,target_cn0,n,step_ms);
+        if(print_now){
+            double rdot_pred = los[0]*vsat[0] + los[1]*vsat[1] + los[2]*vsat[2];
+            double rdot_fd = -CLIGHT*ch[i].fd/F_B1I;
+            double delta = rdot_pred - rdot_fd;
+            printf("[delta] PRN%02d %.3f %.3f %.3f\n", prn, rdot_pred, rdot_fd, delta);
+        }
         if(el < 5.0) ch[i].amp = 0.0;     /* below horizon → mute */
 
         /* predict next dynamics using next position/velocity */
@@ -168,10 +191,10 @@ static void update_channels_path(channel_t *ch,int n,
         int week2 = (int)(t_abs/604800.0);
         double sow2 = t_abs - week2*604800.0;
         double sat2[3], rho2, rdot2;
-        compute_range_rate(prn,week2,sow2,u_next,uvel_next,sat2,&rho2,&rdot2);
-        double enu2[3]; ecef2enu(u_next,sat2,enu2);
+        compute_range_rate(prn,week2,sow2,u_next,uvel_next,sat2,NULL,&rho2,&rdot2,NULL);
+        double enu2[3]; ecef_to_enu(u_next,sat2,enu2);
         double el2 = enu_elevation_deg(enu2);
-        double fd2 = -FCARRIER*rdot2/CLIGHT;
+        double fd2 = -F_B1I*rdot2/CLIGHT;
         double cr2 = CHIPRATE*(1.0 - rdot2/CLIGHT);
         double A2 = predict_next_amp(&ch[i], rho2, el2, gain, target_cn0, n, step_ms);
         if(el2 < 5.0) A2 = 0.0;
@@ -195,8 +218,12 @@ void generate_signal(const sim_config_t *cfg)
         free_path(&path);
         return;
     }
-    if(cfg->path_type==0)      llh2xyz(cfg->llh,&usr);
-    else { interpolate_path(&path,0.0,&usr); xyz2llh(usr.xyz,&usr); }
+    if(cfg->path_type==0){
+        double llh_rad[3]={cfg->llh[0]*M_PI/180.0,
+                           cfg->llh[1]*M_PI/180.0,
+                           cfg->llh[2]};
+        lla_to_ecef(llh_rad,&usr);
+    } else { interpolate_path(&path,0.0,&usr); ecef_to_lla(usr.xyz,&usr); }
     if(utc_to_bdt(cfg->time_start,&usr.week,&usr.sow)!=0){
         fputs("UTC format err\n",stderr);
         free_path(&path);
@@ -269,9 +296,9 @@ void generate_signal(const sim_config_t *cfg)
             interpolate_path(&path, ms/1000.0, &u0);
             interpolate_path(&path, (ms+STEP_MS)/1000.0, &u1);
             interpolate_path(&path, (ms+2*STEP_MS)/1000.0, &u2);
-            xyz2llh(u0.xyz,&usr); usr.week=week; usr.sow=sow;
-            xyz2llh(u1.xyz,&usr_next);
-            xyz2llh(u2.xyz,&u2);
+            ecef_to_lla(u0.xyz,&usr); usr.week=week; usr.sow=sow;
+            ecef_to_lla(u1.xyz,&usr_next);
+            ecef_to_lla(u2.xyz,&u2);
             uvel[0]=(u1.xyz[0]-u0.xyz[0])/dt;
             uvel[1]=(u1.xyz[1]-u0.xyz[1])/dt;
             uvel[2]=(u1.xyz[2]-u0.xyz[2])/dt;
@@ -303,7 +330,7 @@ void generate_signal(const sim_config_t *cfg)
         }
         if(ms==0){
             for(int i=0;i<n_ch;++i){
-                double rdot = -ch[i].fd*CLIGHT/FCARRIER;
+                double rdot = -ch[i].fd*CLIGHT/F_B1I;
                 printf("[ch%02d] rdot %.2f fd %.2fHz\n", ch[i].prn, rdot, ch[i].fd);
             }
         }

--- a/channel.c
+++ b/channel.c
@@ -9,7 +9,7 @@
 #include "orbits.h"                /* calc_sat_position_velocity */
 
 #define PI2        6.2831853071795864769
-#define FCARRIER   1561.098e6      /* B1I */
+#define F_B1I      1561.098e6      /* B1I carrier */
 #define CHIPRATE   2.046e6
 static double fs = FS_OUTPUT_HZ;           /* default sample rate */
 
@@ -235,7 +235,7 @@ void update_channel_dynamics(channel_t *c,double rho,double rdot,double elev_deg
     c->amp = smooth_amp(c->amp, A_new, dt_ms);
     c->amp_dot = 0.0;
     c->elev_deg = elev_deg;
-    c->fd  = -FCARRIER*rdot/CLIGHT;               /* Doppler (Hz) */
+    c->fd  = -F_B1I*rdot/CLIGHT;                  /* Doppler (Hz) */
     c->code_rate = CHIPRATE*(1.0 - rdot/CLIGHT);  /* Code frequency (Hz) */
 }
 

--- a/coord.c
+++ b/coord.c
@@ -1,34 +1,32 @@
 #include "coord.h"
 #include "globals.h"     /* nav_week */
-/* 地球自轉角速度 (rad/s) */
-#define OMEGA_E   7.2921150e-5
 
-/* LLH → ECEF，並把 llh/xyz 一併寫回 coord_t -------------- */
-void llh2xyz(const double llh_deg[3], coord_t *c)
+/* LLA(rad) → ECEF，並把 llh/xyz 一併寫回 coord_t -------------- */
+void lla_to_ecef(const double lla[3], coord_t *c)
 {
-    const double lat = llh_deg[0] * (M_PI/180.0);
-    const double lon = llh_deg[1] * (M_PI/180.0);
-    const double  h  = llh_deg[2];
+    const double lat = lla[0];
+    const double lon = lla[1];
+    const double  h  = lla[2];
 
-    /* 儲存原始 llh (deg) 方便之後 ecef2enu 使用 */
-    c->llh[0] = llh_deg[0];
-    c->llh[1] = llh_deg[1];
-    c->llh[2] = llh_deg[2];
+    /* 儲存原始 llh (rad) 方便之後 ecef_to_enu 使用 */
+    c->llh[0] = lat;
+    c->llh[1] = lon;
+    c->llh[2] = h;
 
     /* WGS-84 精確轉換 ------------------------------------------------ */
     const double sinp = sin(lat);
-    const double N = WGS_A / sqrt(1.0 - WGS_E2 * sinp * sinp);
+    const double N = WGS84_A / sqrt(1.0 - WGS84_E2 * sinp * sinp);
 
     c->xyz[0] = (N + h) * cos(lat) * cos(lon);
     c->xyz[1] = (N + h) * cos(lat) * sin(lon);
-    c->xyz[2] = (N * (1.0 - WGS_E2) + h) * sinp;
+    c->xyz[2] = (N * (1.0 - WGS84_E2) + h) * sinp;
 }
 
-/* ECEF → LLH ------------------------------------------------------- */
-void xyz2llh(const double xyz[3], coord_t *c)
+/* ECEF → LLA(rad) -------------------------------------------------- */
+void ecef_to_lla(const double xyz[3], coord_t *c)
 {
     const double x=xyz[0], y=xyz[1], z=xyz[2];
-    const double a=WGS_A, e2=WGS_E2;
+    const double a=WGS84_A, e2=WGS84_E2;
     double lon=atan2(y,x);
     double p=hypot(x,y);
     double lat=atan2(z,p*(1.0-e2));
@@ -39,17 +37,17 @@ void xyz2llh(const double xyz[3], coord_t *c)
     }
     double N=a/sqrt(1.0-e2*sin(lat)*sin(lat));
     double h=p/cos(lat)-N;
-    c->llh[0]=lat*(180.0/M_PI);
-    c->llh[1]=lon*(180.0/M_PI);
+    c->llh[0]=lat;
+    c->llh[1]=lon;
     c->llh[2]=h;
     c->xyz[0]=x; c->xyz[1]=y; c->xyz[2]=z;
 }
 
 /* ECEF → ENU ------------------------------------------------------- */
-void ecef2enu(const coord_t *usr, const double sat_xyz[3], double enu[3])
+void ecef_to_enu(const coord_t *usr, const double sat_xyz[3], double enu[3])
 {
-    const double lat = usr->llh[0] * (M_PI/180.0);
-    const double lon = usr->llh[1] * (M_PI/180.0);
+    const double lat = usr->llh[0];
+    const double lon = usr->llh[1];
 
     const double dx = sat_xyz[0] - usr->xyz[0];
     const double dy = sat_xyz[1] - usr->xyz[1];
@@ -71,34 +69,23 @@ double enu_elevation_deg(const double enu[3])
     return asin( enu[2] / rho ) * 180.0 / M_PI;
 }
 
-/* ECEF → ECI ------------------------------------------------------- */
-void ecef_to_eci(const double ecef[3],int week,double sow,double eci[3])
-{
-    double t = (week - nav_week)*604800.0 + sow;
-    double theta = -OMEGA_E * t;
-    double cosT = cos(theta), sinT = sin(theta);
-    eci[0] = cosT*ecef[0] - sinT*ecef[1];
-    eci[1] = sinT*ecef[0] + cosT*ecef[1];
-    eci[2] = ecef[2];
-}
-
 /* Fixed user in ECEF (no extra Earth-rotation on receiver) */
 void static_user_at(int week, double sow, const coord_t *ref,
                     coord_t *out, double vel[3])
 {
-    double lat = ref->llh[0] * (M_PI/180.0);
-    double lon = ref->llh[1] * (M_PI/180.0);
+    double lat = ref->llh[0];
+    double lon = ref->llh[1];
     double h   = ref->llh[2];
 
     double sinp = sin(lat), cosp = cos(lat);
-    double N = WGS_A / sqrt(1.0 - WGS_E2 * sinp * sinp);
+    double N = WGS84_A / sqrt(1.0 - WGS84_E2 * sinp * sinp);
 
-    /* ECEF position from LLH (WGS-84) — NO time-rotation on longitude */
+    /* ECEF position from LLA (WGS-84) — NO time-rotation on longitude */
     out->xyz[0] = (N + h) * cosp * cos(lon);
     out->xyz[1] = (N + h) * cosp * sin(lon);
-    out->xyz[2] = (N * (1.0 - WGS_E2) + h) * sinp;
+    out->xyz[2] = (N * (1.0 - WGS84_E2) + h) * sinp;
 
-    /* Echo LLH/time tags (for bookkeeping only) */
+    /* Echo LLA/time tags (for bookkeeping only) */
     out->llh[0] = ref->llh[0];
     out->llh[1] = ref->llh[1];
     out->llh[2] = ref->llh[2];

--- a/coord.h
+++ b/coord.h
@@ -1,25 +1,20 @@
 #ifndef COORD_H
 #define COORD_H
 #include <math.h>
-
-/* WGS-84 */
-#define WGS_A   6378137.0
-#define WGS_F   (1.0/298.257223563)
-#define WGS_E2  (WGS_F*(2.0-WGS_F))
+#include "orbits.h"  /* WGS84 constants */
 
 typedef struct {
-    double llh[3];   /* [deg,deg,m]  使用者原始經緯高 */
+    double llh[3];   /* [rad,rad,m]  使用者原始經緯高 */
     double xyz[3];   /* [m]          對應 ECEF */
     int    week;     /* BDT 周 & 秒，可由主程式填入 */
     double sow;
 } coord_t;
 
 /* 介面 ----------------------------------------------------- */
-void   llh2xyz(const double llh_deg[3], coord_t *c);
-void   xyz2llh(const double xyz[3], coord_t *c);
-void   ecef2enu(const coord_t *usr, const double sat_xyz[3], double enu[3]);
+void   lla_to_ecef(const double lla[3], coord_t *c);
+void   ecef_to_lla(const double xyz[3], coord_t *c);
+void   ecef_to_enu(const coord_t *usr, const double sat_xyz[3], double enu[3]);
 double enu_elevation_deg(const double enu[3]);
-void   ecef_to_eci(const double ecef[3],int week,double sow,double eci[3]);
 void   static_user_at(int week,double sow,const coord_t *ref,coord_t *out,double vel[3]);
 
 #endif

--- a/main.c
+++ b/main.c
@@ -213,10 +213,14 @@ int main(int argc,char *argv[])
         free_path(&path);
         return 1;
     }
-    if(cfg.path_type==0)      llh2xyz(cfg.llh,&usr);
-    else {                    
+    if(cfg.path_type==0){
+        double llh_rad[3]={cfg.llh[0]*M_PI/180.0,
+                           cfg.llh[1]*M_PI/180.0,
+                           cfg.llh[2]};
+        lla_to_ecef(llh_rad,&usr);
+    } else {
         interpolate_path(&path,0.0,&usr);
-        xyz2llh(usr.xyz,&usr);
+        ecef_to_lla(usr.xyz,&usr);
     }
     usr.week = start_week;
     usr.sow  = start_sow;

--- a/orbits.c
+++ b/orbits.c
@@ -6,9 +6,9 @@
 #include <math.h>
 #include <stddef.h>
 #include "bdssim.h"          /* 提供 ephemeris_t 及 eph[] 全域陣列 */
+#include "orbits.h"          /* OMEGA_E, WGS84 constants */
 
 #define GM        3.986004418e14       /* WGS-84 μ  (m^3/s^2) */
-#define OMEGA_E   7.2921150e-5         /* 地球自轉角速度 (rad/s) */
 
 
 /* --------------------------------------------------------------*/
@@ -24,7 +24,7 @@ static double kepler(double M, double e)
 }
 
 /* --------------------------------------------------------------*/
-/*          主要 API：回傳 ECEF 位置 xyz 與速度 vel               */
+/*          主要 API：回傳 ECEF at t_tx 的位置 xyz 與速度 vel      */
 void calc_sat_position_velocity(int prn, int week, double sow,
                                 double *xyz, double *vel, double *clk)
 {
@@ -75,7 +75,7 @@ void calc_sat_position_velocity(int prn, int week, double sow,
      * Ω(t) = Ω₀ + (Ω̇ − Ωₑ) · tk − Ωₑ · Toe */
     double Omega = ep->omega0 + (ep->omegadot - OMEGA_E) * tk - OMEGA_E * ep->toe;
 
-    /* -------- ECI (WGS-84 inertial) 座標 ----------------------- */
+    /* -------- ECEF at transmit time t_tx ----------------------- */
     const double cosO = cos(Omega), sinO = sin(Omega);
     const double cosi = cos(i),     sini = sin(i);
 
@@ -83,7 +83,7 @@ void calc_sat_position_velocity(int prn, int week, double sow,
     const double y = x_op * sinO + y_op * cosi * cosO;
     const double z = y_op * sini;
 
-    /* ---- 若需要速度，先在 ECI 求導 --------------------------- */
+    /* ---- 若需要速度，直接在 ECEF 框架求導 --------------------- */
     double x_dot = 0.0, y_dot = 0.0, z_dot = 0.0;
     if (vel) {
         const double Edot   = n / (1 - ep->e * cosE);

--- a/orbits.h
+++ b/orbits.h
@@ -1,8 +1,18 @@
 #ifndef ORBITS_H
 #define ORBITS_H
-/* Compute satellite position, velocity and clock bias/drift at given time */
-void calc_sat_position_velocity(int prn,int week,double sow,
-                                double *xyz,double *vel,double *clk);
+
+/* WGS-84 and Earth-rotation constants */
+#define OMEGA_E   7.2921151467e-5      /* Earth rotation rate (rad/s) */
+#define WGS84_A   6378137.0            /* semi-major axis (m) */
+#define WGS84_E2  6.69437999014e-3     /* first eccentricity squared */
+
+/* Compute satellite position/velocity and clock bias/drift.
+ *
+ * All returned coordinates are in the ECEF frame at transmit time t_tx.
+ */
+void calc_sat_position_velocity(int prn, int week, double sow,
+                                double *xyz, double *vel, double *clk);
+
 #endif
 
 

--- a/path.c
+++ b/path.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+#include <math.h>
 #include "path.h"
 
 static void trim(char *s)
@@ -42,7 +43,9 @@ static int parse_llh(const char *buf, coord_t *out)
     double lat, lon, h;
     if (sscanf(buf, "%lf%lf%lf", &lat, &lon, &h) != 3)
         return -1;
-    llh2xyz((double[3]){lat, lon, h}, out);
+    lat *= M_PI/180.0;
+    lon *= M_PI/180.0;
+    lla_to_ecef((double[3]){lat, lon, h}, out);
     return 0;
 }
 
@@ -66,7 +69,9 @@ static int parse_nmea_gga(const char *buf, coord_t *out)
     if (ew == 'W')
         lon = -lon;
 
-    llh2xyz((double[3]){lat, lon, alt}, out);
+    lat *= M_PI/180.0;
+    lon *= M_PI/180.0;
+    lla_to_ecef((double[3]){lat, lon, alt}, out);
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- Centralize Earth and WGS84 constants and clarify ephemeris solver outputs as ECEF at transmit time
- Rotate satellite states to receiver time once in the simulator and add per-second range-rate consistency checks
- Use radian-based LLA/ECEF utilities and map range rate to Doppler/code rate with B1I constants

## Testing
- `make`
- `make check`
- `./bds-sim --rinex BRDM00DLR_S_20251760000_01D_MN.rnx --start 2025/06/25,00:00:00 --llh 30,120,0 --duration 1 --gain 0.1`

------
https://chatgpt.com/codex/tasks/task_e_68a75cdf2d5883278de6e7ed7516bc3d