### PR TITLE
Account for Earth rotation in static user velocity

### DIFF
--- a/bdssim.c
+++ b/bdssim.c
@@ -283,12 +283,9 @@ void generate_signal(const sim_config_t *cfg)
         double uvel[3], uvel_next[3];
         coord_t usr_next={0};
         if(cfg->path_type==0){
-            usr.week = week;
-            usr.sow  = sow;
-            usr_next = usr;
-            usr_next.sow = sow + dt;
-            uvel[0]=uvel[1]=uvel[2]=0.0;
-            uvel_next[0]=uvel_next[1]=uvel_next[2]=0.0;
+            /* Static user: include Earth-rotation velocity */
+            static_user_at(week, sow, &ref_llh, &usr, uvel);
+            static_user_at(week, sow + dt, &ref_llh, &usr_next, uvel_next);
             update_channels_path(ch,n_ch,&usr,uvel,&usr_next,uvel_next,
                                  cfg->gain,g_target_cn0,STEP_MS);
         } else if(cfg->path_type==1){

--- a/coord.c
+++ b/coord.c
@@ -69,7 +69,7 @@ double enu_elevation_deg(const double enu[3])
     return asin( enu[2] / rho ) * 180.0 / M_PI;
 }
 
-/* Fixed user in ECEF (no extra Earth-rotation on receiver) */
+/* Fixed user in ECEF. If vel!=NULL, return velocity from Earth rotation. */
 void static_user_at(int week, double sow, const coord_t *ref,
                     coord_t *out, double vel[3])
 {
@@ -92,10 +92,11 @@ void static_user_at(int week, double sow, const coord_t *ref,
     out->week = week;
     out->sow  = sow;
 
-    if (vel) {  /* Static receiver in ECEF */
-        vel[0] = 0.0;
-        vel[1] = 0.0;
-        vel[2] = 0.0;
+    if (vel) {
+        /* Velocity in ECEF from Earth rotation: v = Ω × r */
+        vel[0] = -OMEGA_E * out->xyz[1];
+        vel[1] =  OMEGA_E * out->xyz[0];
+        vel[2] =  0.0;
     }
 }
 


### PR DESCRIPTION
## Summary
- compute Earth-rotation velocity for static users
- use this velocity when updating channels to avoid Doppler bias

## Testing
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_68a830d48f948327be9b9b8505c906f7