### PR TITLE
feat: add 1 kHz IF for byte output

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,10 @@ careful not to interpret the file as 8‑bit data—otherwise the Q channel
 may appear to contain only zeros or `-1` values.
 Using the `--byte` flag writes `beidou_b1i_u8.bin` containing the **8‑bit**
 I channel only, sampled at **25 MHz** for use with GNSS‑SDR.  The samples are
-generated directly from the internal accumulator rather than converting the
-16‑bit stream.  All output values are normalised to remain within ±1 before
-quantisation so the integers never exceed the format limits.
+mixed to a **1 kHz IF** and generated directly from the internal accumulator
+rather than converting the 16‑bit stream.  All output values are normalised to
+remain within ±1 before quantisation so the integers never exceed the format
+limits.
 The legacy option `-byte` is still recognised as an alias for `--byte`.
 
 ## 訊號型別
@@ -111,7 +112,7 @@ reduce signal strength excessively.
 
 `--seed` specifies the random seed for the initial carrier phase of each channel. The default is `1`.
 
-`--byte`  saves an 8‑bit file containing only the I samples.
+`--byte`  saves an 8‑bit file containing only the real samples mixed to a 1 kHz IF.
 
 `--start` specifies the UTC start time; `--duration` is in seconds and
 `--llh` defines the user location in degrees and meters. The start time may
@@ -172,13 +173,14 @@ Ensure any analysis or playback software reads the file as 16‑bit
 integers; using 8‑bit interpretation will yield
 Q samples that look like zeros.
 When `--byte` is used, the output file `beidou_b1i_u8.bin` stores only the
-I samples in signed 8‑bit format at **25 MHz**.  Only the real component is retained;
-Q is not saved.
+I samples in signed 8‑bit format at **25 MHz** and is mixed to a **1 kHz IF**.
+Only the real component is retained; Q is not saved.
 
-The signal is at baseband (zero‑IF), so tune the
-SDR’s RF centre frequency to the desired transmit frequency – for B1I
-this is typically **1561.098 MHz** – and play the samples at the same
-rate.  The following command illustrates playback with a HackRF:
+The 16‑bit file is at baseband (zero‑IF), so tune the SDR’s RF centre
+frequency to the desired transmit frequency – for B1I this is typically
+**1561.098 MHz** – and play the samples at the same rate.  For the
+`--byte` file, offset the SDR tuning by 1 kHz to account for the IF.
+The following command illustrates playback with a HackRF:
 
 ```bash
 hackrf_transfer -t beidou_b1i.bin -f 1561098000 -s 5120000 -x 0

--- a/bdssim.c
+++ b/bdssim.c
@@ -15,6 +15,7 @@
 #include "globals.h"     /* nav_week, CLIGHT */
 #define FSAMP_DEF FS_OUTPUT_HZ    /* default 6.144 MHz for 16-bit I/Q output */
 #define FSAMP_BYTE 25.0e6    /* 25 MHz when --byte is used */
+#define IF_BYTE    1000.0    /* 1 kHz IF for --byte output */
 #define F_B1I      1561.098e6      /* B1I carrier */
 #define CHIPRATE   2.046e6
 
@@ -253,6 +254,14 @@ void generate_signal(const sim_config_t *cfg)
     int samp_per_ms = (int)(fs/1000.0 + 0.5);
     channel_set_fs(fs);                   /* ensure dynamics use correct Fs */
 
+    double c_if = 1.0, s_if = 0.0;        /* mixer state for byte output */
+    double cos_d = 1.0, sin_d = 0.0;      /* per-sample rotation */
+    if(cfg->byte_output){
+        double w_if = 2*M_PI*IF_BYTE/fs;
+        cos_d = cos(w_if);
+        sin_d = sin(w_if);
+    }
+
     FILE *fp=NULL, *fp8=NULL;
     if(cfg->byte_output){
         fp8=fopen("beidou_b1i_u8.bin","wb");
@@ -358,7 +367,8 @@ void generate_signal(const sim_config_t *cfg)
 
             /* 限幅並打包成 I/Q */
             int16_t iq[2*samp_per_ms];
-            int8_t  i8[samp_per_ms];            /* byte output holds I only */
+            int8_t  i8[samp_per_ms];            /* byte output holds real IF signal */
+            double c = c_if, s = s_if;
             for(int k=0;k<samp_per_ms;++k){
                 int32_t i=accI[k];
                 int32_t q=accQ[k];
@@ -373,12 +383,18 @@ void generate_signal(const sim_config_t *cfg)
                     sumI2 += (double)iq[2*k]*iq[2*k];
                     sumQ2 += (double)iq[2*k+1]*iq[2*k+1];
                 } else {
-                    if (i>127) i=127; else if (i<-128) i=-128;
-                    i8[k] = (int8_t)i;
+                    double mixed = (double)i*c - (double)q*s;
+                    int32_t m = (int32_t)llround(mixed);
+                    if (m>127) m=127; else if (m<-128) m=-128;
+                    i8[k] = (int8_t)m;
                     sumI  += i8[k];
                     sumI2 += (double)i8[k]*i8[k];
+                    double tc = c*cos_d - s*sin_d;
+                    double ts = s*cos_d + c*sin_d;
+                    c = tc; s = ts;
                 }
             }
+            if(!fp){ c_if = c; s_if = s; }
             sample_count += samp_per_ms;
             samp_cnt += samp_per_ms;
             if(fp)

--- a/main.c
+++ b/main.c
@@ -25,7 +25,7 @@ static void usage(const char *p)
     puts("  --gain amp           輸出增益 (>0)");
     puts("  -cn0 value          目標 CN0 (dB-Hz)");
     puts("  --seed n            亂數種子 (整數)");
-    puts("  --byte               輸出 I-only 之 8-bit 檔");
+    puts("  --byte               輸出 I-only 之 8-bit 檔 (1kHz IF)");
     puts("  --meo-only          僅模擬 MEO 衛星");
     puts("  --prn N             僅模擬指定 PRN");
     puts("  --prn37             僅使用 1-37 號衛星");
@@ -272,7 +272,7 @@ int main(int argc,char *argv[])
     /* 5. 結束 --------------------------------------- */
     cleanup_simulator();
     if(cfg.byte_output)
-        puts("[done] beidou_b1i_u8.bin (I-only) 已產生");
+        puts("[done] beidou_b1i_u8.bin (I-only, 1kHz IF) 已產生");
     else
         puts("[done] beidou_b1i.bin 已產生");
     return 0;


### PR DESCRIPTION
## Summary
- Mix 8-bit byte mode output to a 1 kHz intermediate frequency
- Document and CLI help now describe the 1 kHz IF byte output

## Testing
- `make`
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_68aa6498beac83278834f32180676e8a