### PR TITLE
Invert Doppler parameter sign

### DIFF
--- a/bdssim.c
+++ b/bdssim.c
@@ -187,7 +187,7 @@ static void update_channels_path(channel_t *ch,int n,
         double enu2[3]; ecef_to_enu(u_next,sat2,enu2);
         el2[i] = enu_elevation_deg(enu2);
         if(el2[i] >= 5.0) n_vis_next++;
-        fd2[i] = F_B1I*rdot2[i]/CLIGHT;
+        fd2[i] = -F_B1I*rdot2[i]/CLIGHT;
         cr2[i] = CHIPRATE*(1.0 - rdot2[i]/CLIGHT);
     }
 
@@ -339,7 +339,7 @@ void generate_signal(const sim_config_t *cfg)
 
         if(ms==0){
             for(int i=0;i<n_ch;++i){
-                double rdot = ch[i].fd * CLIGHT / F_B1I;
+                double rdot = -ch[i].fd * CLIGHT / F_B1I;
                 printf("[ch%02d] rdot %.2f fd %.2fHz\n", ch[i].prn, rdot, ch[i].fd);
             }
         }

--- a/channel.c
+++ b/channel.c
@@ -204,7 +204,7 @@ void update_channel_dynamics(channel_t *c,double rho,double rdot,double elev_deg
     c->amp = smooth_amp(c->amp, A_new, dt_ms);
     c->amp_dot = 0.0;
     c->elev_deg = elev_deg;
-    c->fd  = F_B1I*rdot/CLIGHT;                   /* Doppler (Hz) */
+    c->fd  = -F_B1I*rdot/CLIGHT;                  /* Doppler (Hz) */
     c->code_rate = CHIPRATE*(1.0 - rdot/CLIGHT);  /* Code frequency (Hz) */
 }
 


### PR DESCRIPTION
## Summary
- invert Doppler sign when updating channel dynamics
- negate subsequent Doppler computations and debug output

## Testing
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_68ab2b5d29988327886ac2820da98fd1