### PR TITLE
Support IQ byte output

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,11 @@ default the file is written at **5.2 MHz**.  Each sample is a pair of
 16‑bit integers `(I,Q)` so be
 careful not to interpret the file as 8‑bit data—otherwise the Q channel
 may appear to contain only zeros or `-1` values.
-Using the `--byte` flag writes `beidou_b1i_u8.bin` containing the **8‑bit**
-I channel only, sampled at **25 MHz** for use with GNSS‑SDR.  The samples are
-mixed to a **1 kHz IF** and generated directly from the internal accumulator
-rather than converting the 16‑bit stream.  All output values are normalised to
-remain within ±1 before quantisation so the integers never exceed the format
-limits.
+Using the `--byte` flag writes `beidou_b1i_u8.bin` containing **8‑bit**
+interleaved I/Q samples at **25 MHz**.  The samples are at **0 Hz IF**
+(baseband) and generated directly from the internal accumulator rather than converting the
+16‑bit stream.  All output values are normalised to remain within ±1 before
+quantisation so the integers never exceed the format limits.
 The legacy option `-byte` is still recognised as an alias for `--byte`.
 
 ## 訊號型別
@@ -112,7 +111,7 @@ reduce signal strength excessively.
 
 `--seed` specifies the random seed for the initial carrier phase of each channel. The default is `1`.
 
-`--byte`  saves an 8‑bit file containing only the real samples mixed to a 1 kHz IF.
+`--byte`  saves an 8‑bit file containing interleaved I and Q samples at a 0 Hz IF.
 
 `--start` specifies the UTC start time; `--duration` is in seconds and
 `--llh` defines the user location in degrees and meters. The start time may
@@ -172,14 +171,12 @@ I/Q samples written at a fixed **5.2 MHz** sample rate.
 Ensure any analysis or playback software reads the file as 16‑bit
 integers; using 8‑bit interpretation will yield
 Q samples that look like zeros.
-When `--byte` is used, the output file `beidou_b1i_u8.bin` stores only the
-I samples in signed 8‑bit format at **25 MHz** and is mixed to a **1 kHz IF**.
-Only the real component is retained; Q is not saved.
+When `--byte` is used, the output file `beidou_b1i_u8.bin` stores interleaved
+I and Q samples in signed 8‑bit format at **25 MHz** at baseband (0 Hz IF).
 
-The 16‑bit file is at baseband (zero‑IF), so tune the SDR’s RF centre
+Both the 16‑bit and `--byte` files are at baseband, so tune the SDR’s RF centre
 frequency to the desired transmit frequency – for B1I this is typically
-**1561.098 MHz** – and play the samples at the same rate.  For the
-`--byte` file, offset the SDR tuning by 1 kHz to account for the IF.
+**1561.098 MHz** – and play the samples at the same rate.
 The following command illustrates playback with a HackRF:
 
 ```bash

--- a/bdssim.c
+++ b/bdssim.c
@@ -15,7 +15,7 @@
 #include "globals.h"     /* nav_week, CLIGHT */
 #define FSAMP_DEF FS_OUTPUT_HZ    /* default 5.2 MHz for 16-bit I/Q output */
 #define FSAMP_BYTE 25.0e6    /* 25 MHz when --byte is used */
-#define IF_BYTE    1000.0    /* 1 kHz IF for --byte output */
+#define IF_BYTE    0.0       /* baseband (0 Hz IF) for --byte output */
 #define F_B1I      1561.098e6      /* B1I carrier */
 #define CHIPRATE   2.046e6
 
@@ -364,7 +364,7 @@ void generate_signal(const sim_config_t *cfg)
 
             /* 限幅並打包成 I/Q */
             int16_t iq[2*samp_per_ms];
-            int8_t  i8[samp_per_ms];            /* byte output holds real IF signal */
+            int8_t  iq8[2*samp_per_ms];         /* byte output holds I/Q IF signal */
             double c = c_if, s = s_if;
             for(int k=0;k<samp_per_ms;++k){
                 int32_t i=accI[k];
@@ -373,10 +373,14 @@ void generate_signal(const sim_config_t *cfg)
                     iq[2*k]   = saturate_int16((double)i);
                     iq[2*k+1] = saturate_int16((double)q);
                 } else {
-                    double mixed = (double)i*c - (double)q*s;
-                    int32_t m = (int32_t)llround(mixed);
-                    if (m>127) m=127; else if (m<-128) m=-128;
-                    i8[k] = (int8_t)m;
+                    double mix_i = (double)i*c - (double)q*s;
+                    double mix_q = (double)i*s + (double)q*c;
+                    int32_t mi = (int32_t)llround(mix_i);
+                    int32_t mq = (int32_t)llround(mix_q);
+                    if (mi>127) mi=127; else if (mi<-128) mi=-128;
+                    if (mq>127) mq=127; else if (mq<-128) mq=-128;
+                    iq8[2*k]   = (int8_t)mi;
+                    iq8[2*k+1] = (int8_t)mq;
                     double tc = c*cos_d - s*sin_d;
                     double ts = s*cos_d + c*sin_d;
                     c = tc; s = ts;
@@ -387,7 +391,7 @@ void generate_signal(const sim_config_t *cfg)
             if(fp)
                 fwrite(iq,sizeof(int16_t),2*samp_per_ms,fp);
             else
-                fwrite(i8,sizeof(int8_t),samp_per_ms,fp8);
+                fwrite(iq8,sizeof(int8_t),2*samp_per_ms,fp8);
 
         }
 
@@ -399,7 +403,7 @@ void generate_signal(const sim_config_t *cfg)
         puts("[bdssim] 完成多星基帶輸出 beidou_b1i.bin");
     } else {
         fclose(fp8);
-        puts("[bdssim] 完成 I-only 基帶輸出 beidou_b1i_u8.bin");
+        puts("[bdssim] 完成 8-bit IQ 基帶輸出 beidou_b1i_u8.bin");
     }
     free_path(&path);
 }

--- a/main.c
+++ b/main.c
@@ -25,7 +25,7 @@ static void usage(const char *p)
     puts("  --gain amp           輸出增益 (>0)");
     puts("  -cn0 value          目標 CN0 (dB-Hz)");
     puts("  --seed n            亂數種子 (整數)");
-    puts("  --byte               輸出 I-only 之 8-bit 檔 (1kHz IF)");
+    puts("  --byte               輸出 8-bit IQ 檔 (0 Hz IF)");
     puts("  --meo-only          僅模擬 MEO 衛星");
     puts("  --prn N             僅模擬指定 PRN");
     puts("  --prn37             僅使用 1-37 號衛星");
@@ -272,7 +272,7 @@ int main(int argc,char *argv[])
     /* 5. 結束 --------------------------------------- */
     cleanup_simulator();
     if(cfg.byte_output)
-        puts("[done] beidou_b1i_u8.bin (I-only, 1kHz IF) 已產生");
+        puts("[done] beidou_b1i_u8.bin (8-bit IQ, 0 Hz IF) 已產生");
     else
         puts("[done] beidou_b1i.bin 已產生");
     return 0;


### PR DESCRIPTION
## Summary
- Change `--byte` mode to generate interleaved 8-bit IQ samples at a 0 Hz IF while retaining the 25 MHz sample rate
- Update CLI messages and documentation to reflect baseband byte output

## Testing
- `make check`
- `make bds-sim`


------
https://chatgpt.com/codex/tasks/task_e_68ab47c4963883278eca020c36d977da