### PR TITLE
style: restore banner comments and drop gps-sdr-sim

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,218 +1,104 @@
 # BDS-SDRSIM
 
-This project generates synthetic BeiDou B1I baseband samples for SDR
-experiments.  Navigation data is read from a RINEX navigation file and
-converted into the binary subframe format required by receivers.
+BDS-SDRSIM is an open-source C simulator that synthesizes BeiDou B1I baseband signals for software-defined radio experiments.（BDS-SDRSIM 是一個以 C 語言撰寫的開源模擬器，可產生北斗 B1I 基帶訊號供 SDR 測試）
 
-## Project Summary
-BDS-SDRSIM converts RINEX ephemeris into BeiDou B1I navigation frames and outputs complex baseband samples for software-defined radios. It supports the D1 message, static or dynamic user motion and configurable power.
+## Features
+- **Signal output**: Generates interleaved I/Q samples in 16-bit (5.2 MHz) or 8-bit (25 MHz) format.（輸出 16 位元或 8 位元的 I/Q 樣本）
+- **Navigation data**: Builds D1 subframes from RINEX ephemeris and inserts 20‑bit Neumann–Hoffman codes.（從 RINEX 星曆產生 D1 子幀並加入 20 位元 Neumann–Hoffman 序列）
+- **Multi-satellite channels**: Automatically selects visible PRNs or restricts to user-specified sets.（自動選取可視衛星或依參數限制 PRN）
+- **User motion**: Supports fixed LLH coordinates or 1 Hz trajectory files (`--xyz`, `--llh-file`, `--nmea`).（可模擬靜止或動態使用者）
+- **Power control**: Simple link budget model with adjustable gain and target C/N₀.（內建簡易鏈結損失模型，可調整增益與 C/N₀）
+- **No external dependencies**: Portable C code compiled with `make`.（純 C 實作，透過 `make` 即可編譯）
 
+## Architecture and Signal Flow（整體架構與流程）
+1. **Ephemeris parsing** – `rinex.c` reads broadcast parameters from RINEX files.（由 `rinex.c` 解析 RINEX 星曆）
+2. **Satellite state** – `orbits.c` solves Kepler’s equation  
+   `E - e\sin E = M` to obtain the ECEF position and velocity. The range  
+   is `r = A (1 - e\cos E)` and the RAAN is  
+   `Ω(t) = Ω₀ + (Ω̇ - Ωₑ)·tk - Ωₑ·Toe`.（`orbits.c` 使用 Kepler 方程計算衛星軌道及 RAAN）
+3. **Receiver frame** – `coord.c` converts between LLA and ECEF using WGS‑84:  
+   `N = a / \sqrt{1 - e² \sin²φ}`,  
+   `x = (N + h) \cosφ \cosλ`, etc.（`coord.c` 進行 WGS‑84 座標轉換）
+4. **Geometry** – `bdssim.c` iterates to compute pseudorange `ρ` and range rate `ṙ`,  
+   applying Earth rotation `Ωₑτ` for Sagnac correction:  
+   `ρ = ‖r_sat - r_usr‖ - c·Δt_sv`.（`bdssim.c` 求得幾何距離與地球自轉修正）
+5. **Channel model** – `channel.c` derives carrier and code dynamics:  
+   `f_d = -f_B1I·ṙ/c`,  
+   `f_code = f_chip·(1 - ṙ/c)`. Amplitude uses a link budget  
+   `A ∝ 10^{(C/N₀ - 45)/20} · (1/ρ) · G_ant · gain`.（`channel.c` 依多普勒與功率模型產生通道）
+6. **Navigation bits** – `navbits.c` assembles five 6‑s subframes and applies BCH encoding.（`navbits.c` 建構 6 秒的導航子幀並進行 BCH 編碼）
+7. **Sample synthesis** – `bdssim.c` mixes PRN, NH code, navigation bits and carrier to produce interleaved I/Q output.（`bdssim.c` 混合 PRN、NH 以及導航資料產生 I/Q 樣本）
 
-## System Overview
+## Quick Start（快速開始）
+1. **Build**
+   ```bash
+   make
+   ```
+   Produces executable `bds-sim`.（編譯生成 `bds-sim`）
+2. **Fetch ephemeris**
+   ```bash
+   make download-brdm2025176
+   ```
+   Downloads MGEX BRDM file.（下載 MGEX 星曆）
+3. **Run simulation**
+   ```bash
+   ./bds-sim --rinex BRDM00DLR_S_20251760000_01D_MN.rnx \
+             --start 2025/06/25,00:00:00 \
+             --duration 60 \
+             --llh 25.0,121.0,30 \
+             --gain 1.0
+   ```
+   Generates `beidou_b1i.bin` (16‑bit). Add `--byte` for `beidou_b1i_u8.bin`.（預設輸出 16 位元，加入 `--byte` 轉為 8 位元）
+4. **Playback**
+   ```bash
+   hackrf_transfer -t beidou_b1i.bin -f 1561098000 -s 5200000 -x 0
+   ```
+   Sends the samples with HackRF.（以 HackRF 播放樣本）
 
-BDS‑SDRSIM parses BeiDou ephemeris from the RINEX navigation file,
-computes satellite positions and Doppler shifts for the requested start
-time and user location, and builds the B1I navigation subframes.  Each
-enabled satellite channel spreads these bits with the appropriate PRN
-code.  The 50 bps D1 navigation message is further modulated by the
-standard 20‑bit Neumann–Hoffman sequence so that the resulting signal
-matches the BeiDou B1I specification. Finally the channels are summed to
-produce complex baseband samples ready for SDR playback.
-The output is ready to be transmitted by an SDR.
+## Common Options（常用參數）
 
-## 功能總覽
+| Option | Description |
+|--------|-------------|
+| `--rinex file` | RINEX navigation file (required).（指定 RINEX 星曆） |
+| `--start YYYY/MM/DD,hh:mm:ss` | Simulation start time UTC.（模擬起始 UTC 時刻） |
+| `--duration sec` | Simulation length 1–3600 s.（模擬秒數） |
+| `--llh lat,lon,h` | Fixed user position in degrees/meters.（固定使用者位置） |
+| `--xyz/--llh-file/--nmea file` | 1 Hz trajectory file for moving user.（匯入路徑檔模擬移動） |
+| `--gain amp` | Output amplitude gain (>0).（輸出振幅倍率） |
+| `-cn0 value` | Target C/N₀ to balance channel power.（目標 C/N₀） |
+| `--byte` | Output 8‑bit I/Q at 25 MHz.（以 8 位元輸出 25 MHz 樣本） |
+| `--meo-only` | Use only MEO satellites.（僅模擬 MEO 衛星） |
+| `--prn N` | Simulate only PRN N.（指定單一 PRN） |
+| `--prn37` | Restrict to PRN 1–37.（限制 PRN 1–37） |
+| `--seed n` | Random seed.（設定亂數種子） |
 
-程式以 `main.c` 處理命令列與基本參數，並由 `bdssim.c` 統整整個
-模擬流程。`rinex.c` 讀取星曆，`navbits.c` 依時間產生子幀位元，
-`channel.c` 依各衛星計算擴頻與都卜勒，最後由 `bdssim.c` 將所有
-通道的 I/Q 樣本累加成輸出檔。座標轉換與使用者路徑處理分別
-由 `coord.c` 與 `path.c` 負責，其間的資料透過 `ephemeris_t` 與
-`channel_t` 結構傳遞。
+All options: `./bds-sim --help`.（完整參數請見 `./bds-sim --help`）
 
-## Detailed System Description
-
-BDS-SDRSIM reads BeiDou ephemeris from a RINEX navigation file and
-initialises a set of satellite channels. For each simulation step the
-tool computes the user position (static or from a path file), derives
-satellite geometry and Doppler, and updates the channel state. The
-navigation message for subframes 1–5 is generated with correct
-time-of-week. Each channel spreads the bits with its PRN code and the
-samples are summed into a 16‑bit I/Q stream at a fixed 5.2 MHz sample
-rate.
-
-## Build
-
-```
-make
-```
-
-The optional command `make tests/prn_test` builds a small utility that prints
-each PRN number and the first 16 bits of its code in binary using the
-bundled RINEX file.
-
-Run `make check` to build and execute the self test
-(`tests/test_prn`).
-
-The build produces `bds-sim` which outputs a signed `beidou_b1i.bin`
-file containing interleaved **16‑bit little‑endian** I/Q samples. By
-default the file is written at **5.2 MHz**.  Each sample is a pair of
-16‑bit integers `(I,Q)` so be
-careful not to interpret the file as 8‑bit data—otherwise the Q channel
-may appear to contain only zeros or `-1` values.
-Using the `--byte` flag writes `beidou_b1i_u8.bin` containing **8‑bit**
-interleaved I/Q samples at **25 MHz**.  The samples are at **0 Hz IF**
-(baseband) and generated directly from the internal accumulator rather than converting the
-16‑bit stream.  All output values are normalised to remain within ±1 before
-quantisation so the integers never exceed the format limits.
-The legacy option `-byte` is still recognised as an alias for `--byte`.
-
-## 訊號型別
-
-- IGSO/MEO PRN → D1 (50 bps, 有 NH 二次碼)
-- `--meo-only` 僅模擬 MEO 衛星
-- `--prn`  可只輸出指定 PRN
-- `--prn37`  僅使用 1-37 號衛星
-
-MEO 與 IGSO 依據星曆中的 `sqrtA`(軌道半長軸平方根) 分辨。大於 6000 的視
-為 IGSO，否則為 MEO。
-
-## Usage
-
-```
-./bds-sim --rinex BRDM00DLR_S_20251760000_01D_MN.rnx \
-          --start 2025/06/25,00:00:00 \
-          --duration 60 \
-          --gain 1.0 \
-          --llh lat,lon,height \
-          --byte
-```
-
-Example generating only PRN 6:
-
-```
-./bds-sim --rinex BRDM00DLR_S_20251760000_01D_MN.rnx \
-          --prn 6 --duration 60
-```
-
-`--gain` scales the output amplitude.  With the default gain of `1.0`
-the composite signal uses most of the 16‑bit range.  Larger values boost
-the level but may cause clipping.
-
-The amplitude itself is derived from a simple link budget.  Each orbit
-type is assigned a nominal transmit power (about 53 dBm for IGSO and
-55 dBm for MEO).  Orbit type is detected by checking `sqrtA` so that
-IGSO and MEO receive the proper power.
-Path loss is computed from the
-current slant range including a fixed 2 dB atmospheric term.  The gain
-factor multiplies this result before limiting to the 16‑bit output
-range.  The computed power is further adjusted toward the target
-C/N₀ value (45 dB‑Hz by default) so that adding more channels does not
-reduce signal strength excessively.
-
-`--seed` specifies the random seed for the initial carrier phase of each channel. The default is `1`.
-
-`--byte`  saves an 8‑bit file containing interleaved I and Q samples at a 0 Hz IF.
-
-`--start` specifies the UTC start time; `--duration` is in seconds and
-`--llh` defines the user location in degrees and meters. The start time may
-extend up to 24 hours past the last ephemeris in the RINEX file; the simulator
-continues using the nearest ephemeris block for interpolation. These static
-coordinates are mutually exclusive with the dynamic path options
-`--xyz`, `--llh-file` and `--nmea`.
-Run `./bds-sim --help` to see all command options. A brief configuration
-summary is printed before signal generation begins.
-
-### Dynamic user trajectory
-
-Instead of a fixed location you may supply a 1 Hz path file. Three formats are supported:
-
-```
---xyz       ECEF coordinates (x y z in metres)
---llh-file  Geodetic coordinates (lat lon h)
---nmea      NMEA GGA sentences
-```
-
-Example path files are provided in the `examples/` directory. Usage:
-The files contain one position per line at a 1 Hz rate. Coordinates are
-either ECEF XYZ in metres, latitude/longitude/height in degrees and
-metres, or NMEA GGA sentences.
-
-```
+## Dynamic Path Example（動態路徑範例）
+```bash
 ./bds-sim --rinex BRDM00DLR_S_20251760000_01D_MN.rnx \
           --start 2025/06/25,00:00:00 \
           --xyz examples/path_xyz.txt \
           --duration 60
 ```
+The user position updates every second from `examples/path_xyz.txt`.（使用者位置將依檔案每秒更新）
 
-## Code layout
-
-- `navbits.c`  – builds subframes 1–5 from ephemeris data.
-- `channel.c`  – generates PRN code and navigation modulation for each
-  satellite channel.
-- `bdssim.c`   – combines all channels into the final sample stream.
-- `rinex.c`    – small parser for RINEX navigation files.
-
-Subframes 2 and 3 are pre‑built from ephemeris while subframes 1, 4 and
-5 are generated on demand so that the Time‑of‑Week is consistent with
-the simulation start.
-
-### Testing
-
-```
+## Testing（測試）
+Build and run unit tests:
+```bash
 make check
 ```
+Executes `tests/test_prn` and `tests/test_nh_prn`.（執行 PRN 與 NH 序列測試）
 
-This builds and runs `tests/test_prn` to verify PRN handling.
-
-## SDR playback
-
-The file `beidou_b1i.bin` contains interleaved **16‑bit little‑endian**
-I/Q samples written at a fixed **5.2 MHz** sample rate.
-Ensure any analysis or playback software reads the file as 16‑bit
-integers; using 8‑bit interpretation will yield
-Q samples that look like zeros.
-When `--byte` is used, the output file `beidou_b1i_u8.bin` stores interleaved
-I and Q samples in signed 8‑bit format at **25 MHz** at baseband (0 Hz IF).
-
-Both the 16‑bit and `--byte` files are at baseband, so tune the SDR’s RF centre
-frequency to the desired transmit frequency – for B1I this is typically
-**1561.098 MHz** – and play the samples at the same rate.
-The following command illustrates playback with a HackRF:
-
-```bash
-hackrf_transfer -t beidou_b1i.bin -f 1561098000 -s 5200000 -x 0
-```
-
-Use the `-R` option for continuous looping if needed.  Other SDRs can
-transmit the file in a similar manner as long as they support the same
-sample rate.
-
-## Using GNSS-SDR
-
-When analyzing `beidou_b1i_u8.bin` with GNSS-SDR, ensure that the PRNs
-configured in your `gnss-sdr.conf` match the satellites generated by
-`bds-sim`. The standard `gnss-sdr_BDS_B1I_byte.conf` file is preset for
-PRNs 1–17 and may not align with the PRN list printed by the simulator.
-Adjust the `ChannelX.satellite` lines accordingly or set
-`Channels.in_acquisition` to the total channel count so that GNSS-SDR
-searches for the correct PRNs automatically.
-
-## v0.3.0 (2025-07-07)
-* Fix UTC→BDT +4 s
-* Added subframe 4/5 template
-* Default Fs → 5.2 MHz
-* Power scaling by target CN₀
-
-## v0.3.1 (unreleased)
-* Correct subframe 4/5 constant words
-* Minor API cleanup
-* Orbit propagation now applies the standard GPS/BDS RAAN
-  expression `Ω(t) = Ω₀ + (Ω̇ − Ωₑ)·tk − Ωₑ·Toe` for all BeiDou
-  satellites. Results were cross-checked against the provided SP3
-  precise orbit file.
+## Project Structure（專案結構）
+- `bdssim.c` – Main simulation loop and I/Q writer.（核心模擬流程與輸出）
+- `channel.c` – Per‑satellite signal generation and power control.（通道計算與功率模型）
+- `orbits.c` – Satellite orbit and clock model.（衛星軌道與時鐘模型）
+- `navbits.c` – B1I subframe assembly.（導航資料組合）
+- `rinex.c` – RINEX navigation parser.（星曆解析）
+- `coord.c`, `path.c` – Coordinate transforms and user trajectory.（座標轉換與路徑處理）
+- `examples/` – Sample trajectory files.（範例路徑）
+- `tests/` – Unit tests.（測試程式）
 
 ## License
-
-BDS-SDRSIM is released under the MIT License. See the [LICENSE](LICENSE)
-file for details.
-
+Released under the MIT License. See [LICENSE](LICENSE).（以 MIT 授權發布）

--- a/bch.c
+++ b/bch.c
@@ -11,7 +11,7 @@ uint16_t bch_encode(uint16_t d11)
     return (d11<<4) | (reg & 0xF);
 }
 
-/* 對 26 位元資料的後 11 位做 BCH，並在尾端附上 4 位校驗 */
+/* --------------------------- 對 26 位元資料的後 11 位做 BCH，並在尾端附上 4 位校驗 ------------------------------*/
 uint32_t bch_encode_26bit(uint32_t payload)
 {
     payload &= 0x3FFFFFF;                 /* 26 bits */
@@ -20,7 +20,7 @@ uint32_t bch_encode_26bit(uint32_t payload)
     return (payload << 4) | parity;       /* 26 資料 + 4 校驗 */
 }
 
-/* 將 22 位元資料分成兩組 11 位做 BCH，並交錯輸出 */
+/* --------------------------- 將 22 位元資料分成兩組 11 位做 BCH，並交錯輸出 ------------------------------*/
 uint32_t bch_interleave_22bit(uint32_t payload)
 {
     uint16_t high11 = (payload >> 11) & 0x7FF;
@@ -34,3 +34,4 @@ uint32_t bch_interleave_22bit(uint32_t payload)
     }
     return result;
 }
+/* ---------------------------  End  ------------------------------*/

--- a/bdssim.c
+++ b/bdssim.c
@@ -15,7 +15,7 @@
 #define FSAMP_BYTE 25.0e6    /* 25 MHz when --byte is used */
 #define IF_BYTE    0.0       /* baseband (0 Hz IF) for --byte output */
 
-/* ========= 振幅計算與 int16 飽和保護 ========= */
+/* --------------------------- 振幅計算與 int16 飽和保護 ------------------------------*/
 static inline int16_t saturate_int16(double x)
 {
     if (x >  32760.0) return  32760;
@@ -23,7 +23,7 @@ static inline int16_t saturate_int16(double x)
     return (int16_t)llround(x);
 }
 
-/* ---- 檢查模擬起始時間與星曆 toe 差距是否過大 ---- */
+/* --------------------------- 起始時間與星曆 toe 檢查 ------------------------------*/
 static void check_ephemeris_age(int week,double sow)
 {
     double t = week*604800.0 + sow;
@@ -43,7 +43,7 @@ static void check_ephemeris_age(int week,double sow)
         fputs("建議使用接近星曆 toe 的起始時間以避免 tk 錯誤\n", stderr);
 }
 
-/* Compute corrected pseudorange and range rate */
+/* --------------------------- Compute corrected pseudorange and range rate ------------------------------*/
 static void compute_range_rate(int prn,int week,double sow,
                                const coord_t *u,const double uvel[3],
                                double sat_rx[3], double vsat_rx[3],
@@ -120,7 +120,7 @@ static void compute_range_rate(int prn,int week,double sow,
     }
 }
 
-/*----------------------------------------------------*/
+/* --------------------------- Channel selection ------------------------------*/
 int select_channels(channel_t *ch,int *n,const coord_t*u,
                     int single_prn,bool meo_only)
 {
@@ -148,8 +148,7 @@ int select_channels(channel_t *ch,int *n,const coord_t*u,
     return *n;
 }
 
-
-/* 依照使用者軌跡更新通道，使用目前與下一步的幾何資訊 */
+/* --------------------------- 依照使用者軌跡更新通道，使用目前與下一步的幾何資訊 ------------------------------*/
 static void update_channels_path(channel_t *ch,int n,
                                  const coord_t *u,const double uvel[3],
                                  const coord_t *u_next,const double uvel_next[3],
@@ -158,7 +157,7 @@ static void update_channels_path(channel_t *ch,int n,
     double dt = step_ms * 0.001; /* seconds */
 
     double t_abs = u->week*604800.0 + u->sow;
-    /* --- 第一輪：計算幾何與可視衛星數 --- */
+    /* 第一輪：計算幾何與可視衛星數 */
     double rho[MAX_CH], rdot[MAX_CH], el[MAX_CH];
     double rho2[MAX_CH], rdot2[MAX_CH], el2[MAX_CH];
     double fd2[MAX_CH], cr2[MAX_CH];
@@ -190,7 +189,7 @@ static void update_channels_path(channel_t *ch,int n,
     if(n_vis_now < 1) n_vis_now = 1;           /* avoid div-by-zero */
     if(n_vis_next < 1) n_vis_next = 1;
 
-    /* --- 第二輪：更新通道狀態 --- */
+    /* 第二輪：更新通道狀態 */
     for(int i=0;i<n;++i){
         channel_set_time(&ch[i], rho[i]);
         update_channel_dynamics(&ch[i],rho[i],rdot[i],el[i],
@@ -205,7 +204,7 @@ static void update_channels_path(channel_t *ch,int n,
         ch[i].amp_dot = (A2 - ch[i].amp) / dt;
     }
 }
-/*----------------------------------------------------*/
+/* --------------------------- 信號產生 ------------------------------*/
 void generate_signal(const sim_config_t *cfg)
 {
     coord_t usr={0};
@@ -340,7 +339,7 @@ void generate_signal(const sim_config_t *cfg)
             }
         }
 
-        /* --- STEP_MS 次 1ms 取樣 --- */
+        /* STEP_MS 次 1ms 取樣 */
         for(int step=0;step<STEP_MS;++step){
             g_t_tx = start_bdt + sample_count/fs;
             memset(accI,0,sizeof(accI)); memset(accQ,0,sizeof(accQ));
@@ -403,4 +402,4 @@ void generate_signal(const sim_config_t *cfg)
     }
     free_path(&path);
 }
-
+/* ---------------------------  End  ------------------------------*/

--- a/channel.c
+++ b/channel.c
@@ -17,7 +17,7 @@ double g_target_cn0 = 42.0;
 
 /* (舊的接收天線圖與 multipath 模型已移除) */
 
-/* ---------- 32k sin LUT ---------- */
+/* --------------------------- 32k sin LUT ------------------------------*/
 #define LUTBITS   15
 #define LUTSIZE   (1u<<LUTBITS)
 static float sin_lut[LUTSIZE];
@@ -37,8 +37,7 @@ static inline void fast_sincos(double ph,float*co,float*si){
     *co = sin_lut[j] + f*(sin_lut[j2]-sin_lut[j]);
 }
 
-/* ---------- 載波與振幅計算 ---------- */
-
+/* --------------------------- 載波與振幅計算 ------------------------------*/
 
 /* PRNs 1–5 and 59–63 are GEO satellites and are skipped during
  * channel selection. */
@@ -66,8 +65,7 @@ int is_meo_prn(int prn)
     return ep->sqrtA <= 6000.0; /* ~27800 km orbit */
 }
 
-
-/* ---- gps-sdr-sim 風格的振幅模型 ---- */
+/* --------------------------- 振幅模型 ------------------------------*/
 static double ant_pat[37];
 __attribute__((constructor))
 static void init_ant_pat(void){
@@ -79,7 +77,7 @@ static inline double amp_from_geom(double rho,double elev_deg,double gain,
                                    double cn0_dBHz,int n_visible)
 {
     double base = pow(10.0,(cn0_dBHz-45.0)/20.0) * 16384.0;
-    double path_loss = 20200000.0 / rho; /* gps-sdr-sim constant */
+    double path_loss = 20200000.0 / rho; /* 模型常數 */
     int ibs = (int)((90.0 - elev_deg)/5.0);
     if(ibs < 0) ibs = 0; else if(ibs > 36) ibs = 36;
     double ant = ant_pat[ibs];
@@ -94,7 +92,7 @@ static inline double orbit_gain_amp(int prn)
     return pow(10.0, dB/20.0);
 }
 
-/* 指數平滑振幅，避免 AM 旁帶 */
+/* --------------------------- 指數平滑振幅，避免 AM 旁帶 ------------------------------*/
 static inline double smooth_amp(double A_prev, double A_new, double dt_ms)
 {
     double alpha = 1.0 - exp(-dt_ms / AMP_SMOOTH_TC_MS);
@@ -113,14 +111,13 @@ double predict_next_amp(const channel_t *c,double rho_next,double elev_deg_next,
     return smooth_amp(c->amp, A_new, dt_ms);
 }
 
-/* ---------- CA cache ---------- */
+/* --------------------------- CA cache ------------------------------*/
 static int16_t ca_wave[64][CODE_LEN];
 static int     ca_ready=0;
 
 /* BeiDou D1 Neumann-Hoffman 20-bit code (0=+1, 1=-1) */
 
-
-/* ---------- Channel helpers ---------- */
+/* --------------------------- Channel helpers ------------------------------*/
 static void load_ca_once(void)
 {
     if(ca_ready) return;
@@ -164,7 +161,6 @@ void channel_set_time(channel_t *c,double rho)
         c->bit_ptr    = 0;
     }
 
-    /* Debug print removed */
 }
 
 void channel_reset(channel_t *c,int prn,double rho){
@@ -196,7 +192,7 @@ void channel_set_fs(double sample_rate)
     fs = sample_rate;
 }
 
-/* ---------- 產生 1 ms ---------- */
+/* 產生 1 ms */
 void gen_samples_1ms(channel_t *c,int samp_per_ms,int16_t*I,int16_t*Q)
 {
     double fd = c->fd;
@@ -242,4 +238,4 @@ void gen_samples_1ms(channel_t *c,int samp_per_ms,int16_t*I,int16_t*Q)
     c->code_phase = code_phase;
     c->amp = amp;
 }
-
+/* ---------------------------  End  ------------------------------*/

--- a/coord.c
+++ b/coord.c
@@ -1,7 +1,7 @@
 #include "coord.h"
 #include "globals.h"     /* nav_week */
 
-/* LLA(rad) → ECEF，並把 llh/xyz 一併寫回 coord_t -------------- */
+/* --------------------------- LLA(rad) → ECEF，並把 llh/xyz 一併寫回 coord_t ------------------------------*/
 void lla_to_ecef(const double lla[3], coord_t *c)
 {
     const double lat = lla[0];
@@ -13,7 +13,7 @@ void lla_to_ecef(const double lla[3], coord_t *c)
     c->llh[1] = lon;
     c->llh[2] = h;
 
-    /* WGS-84 精確轉換 ------------------------------------------------ */
+    /* WGS-84 精確轉換 */
     const double sinp = sin(lat);
     const double N = WGS84_A / sqrt(1.0 - WGS84_E2 * sinp * sinp);
 
@@ -22,7 +22,7 @@ void lla_to_ecef(const double lla[3], coord_t *c)
     c->xyz[2] = (N * (1.0 - WGS84_E2) + h) * sinp;
 }
 
-/* ECEF → LLA(rad) -------------------------------------------------- */
+/* --------------------------- ECEF → LLA(rad) ------------------------------*/
 void ecef_to_lla(const double xyz[3], coord_t *c)
 {
     const double x=xyz[0], y=xyz[1], z=xyz[2];
@@ -43,7 +43,7 @@ void ecef_to_lla(const double xyz[3], coord_t *c)
     c->xyz[0]=x; c->xyz[1]=y; c->xyz[2]=z;
 }
 
-/* ECEF → ENU ------------------------------------------------------- */
+/* --------------------------- ECEF → ENU ------------------------------*/
 void ecef_to_enu(const coord_t *usr, const double sat_xyz[3], double enu[3])
 {
     const double lat = usr->llh[0];
@@ -61,7 +61,7 @@ void ecef_to_enu(const coord_t *usr, const double sat_xyz[3], double enu[3])
     enu[2] =  cosLon*cosLat*dx + sinLon*cosLat*dy + sinLat*dz;      /* U */
 }
 
-/* 由 ENU 向量計算仰角（deg） --------------------------------------- */
+/* --------------------------- 由 ENU 向量計算仰角（deg） ------------------------------*/
 double enu_elevation_deg(const double enu[3])
 {
     const double rho = sqrt(enu[0]*enu[0] + enu[1]*enu[1] + enu[2]*enu[2]);
@@ -69,7 +69,7 @@ double enu_elevation_deg(const double enu[3])
     return asin( enu[2] / rho ) * 180.0 / M_PI;
 }
 
-/* Fixed user in ECEF. If vel!=NULL, return velocity from Earth rotation. */
+/* --------------------------- 固定使用者：ECEF 位置與地球自轉速度 ------------------------------*/
 void static_user_at(int week, double sow, const coord_t *ref,
                     coord_t *out, double vel[3])
 {
@@ -99,5 +99,4 @@ void static_user_at(int week, double sow, const coord_t *ref,
         vel[2] =  0.0;
     }
 }
-
-
+/* ---------------------------  End  ------------------------------*/

--- a/globals.c
+++ b/globals.c
@@ -9,7 +9,7 @@
 #include "bdssim.h"
 #include "rinex.h"
 
-/* ───────────── 全域資料區 ───────────── */
+/* --------------------------- 全域資料區 ------------------------------*/
 uint8_t      prn_code[MAX_SAT][CODE_LEN];   /* Gold 2046-chip */
 ephemeris_t  eph[MAX_SAT];                  /* ★ 真正配置記憶體 ★ */
 
@@ -26,7 +26,7 @@ int prn_max = 63;
 /* Global transmit time (BDT seconds) */
 double g_t_tx = 0.0;
 
-/* ───────────── B1I PRN 產生 ───────────── */
+/* --------------------------- B1I PRN 產生 ------------------------------*/
 #define ITER 2047                     /* 先跑滿 2047，再丟掉最後 1 chip */
 
 /* 求 11-bit 內容在 mask 位置上的 XOR parity */
@@ -72,7 +72,7 @@ static void init_prn_table(void)
     printf("[bdssim] PRN 表已產生 (1–%d)\n", prn_max);
 }
 
-/* ───────────── 對外 API ───────────── */
+/* 對外 API */
 bool init_simulator(sim_config_t *cfg, double start_bdt)
 {
     if(simulator_inited) return true;
@@ -85,4 +85,4 @@ bool init_simulator(sim_config_t *cfg, double start_bdt)
     return true;
 }
 void cleanup_simulator(void){ simulator_inited = 0; }
-
+/* ---------------------------  End  ------------------------------*/

--- a/main.c
+++ b/main.c
@@ -12,7 +12,6 @@
 #include "coord.h"
 #include "navbits.h"
 
-/* ───────────────────────────── */
 static void usage(const char *p)
 {
     printf("用法: %s --rinex file --start YYYY/MM/DD,hh:mm:ss [選項]\n", p);
@@ -34,7 +33,7 @@ static void usage(const char *p)
 
 int main(int argc,char *argv[])
 {
-    /* 1. 預設參數 ----------------------------------- */
+    /* 1. 預設參數 */
     sim_config_t cfg = {0};
     cfg.gain        = 1.0;
     cfg.target_cn0  = 45.0;            /* dB-Hz */
@@ -63,7 +62,7 @@ int main(int argc,char *argv[])
         }
     }
 
-    /* 2. 解析 CLI ----------------------------------- */
+    /* 2. 解析 CLI */
     static struct option longopt[] = {
         {"rinex",    required_argument, 0, 'e'},
         {"start",    required_argument, 0, 't'},
@@ -149,7 +148,6 @@ int main(int argc,char *argv[])
         }
     }
 
-
     if(cfg.rinex_file[0]=='\0' || cfg.time_start[0]=='\0'){
         usage(argv[0]); return 1;
     }
@@ -163,7 +161,7 @@ int main(int argc,char *argv[])
         return 1;
     }
 
-    /* --duration 1~3600 sec; --llh lat[-90,90], lon[-180,180], h[-1000,20000] */
+    /* duration 1~3600 sec; --llh lat[-90,90], lon[-180,180], h[-1000,20000] */
     if(cfg.duration==0 || cfg.duration>3600){
         fputs("--duration 範圍 1~3600 秒\n", stderr);
         return 1;
@@ -180,8 +178,6 @@ int main(int argc,char *argv[])
         return 1;
     }
 
-
-
     int start_week; double start_sow;
     if(utc_to_bdt(cfg.time_start, &start_week, &start_sow)!=0){
         fputs("--start 格式錯誤\n", stderr);
@@ -189,20 +185,20 @@ int main(int argc,char *argv[])
     }
     double start_bdt = start_week*604800.0 + start_sow;
 
-    /* 3. 初始化 ------------------------------------- */
+    /* 3. 初始化 */
     if(!init_simulator(&cfg, start_bdt)){
         fprintf(stderr,"初始化失敗\n");
         return 1;
     }
 
-    /* -- start 時間檢查：必須在星曆區間 h-1 ~ h+1 內 -- */
+    /* start 時間檢查：必須在星曆區間 h-1 ~ h+1 內 */
     if(start_bdt < nav_time_min - 3600.0 ||
        start_bdt + cfg.duration > nav_time_max + 86400.0){
         fputs("--start 超出星曆可用區間\n", stderr);
         return 1;
     }
 
-    /* ---- 3-b. 使用者初始座標 ---- */
+    /* 3-b. 使用者初始座標 */
     coord_t usr;
     path_t path={0};
     if(cfg.path_type==1)       load_path_xyz(cfg.path_file,&path);
@@ -265,11 +261,11 @@ int main(int argc,char *argv[])
     if(cfg.single_prn > 0)
         print_ephemeris_params(cfg.single_prn);
 
-    /* 4. 產生基帶 ----------------------------------- */
+    /* 4. 產生基帶 */
     generate_signal(&cfg);
     free_path(&path);
 
-    /* 5. 結束 --------------------------------------- */
+    /* 5. 結束 */
     cleanup_simulator();
     if(cfg.byte_output)
         puts("[done] beidou_b1i_u8.bin (8-bit IQ, 0 Hz IF) 已產生");
@@ -277,4 +273,4 @@ int main(int argc,char *argv[])
         puts("[done] beidou_b1i.bin 已產生");
     return 0;
 }
-
+/* ---------------------------  End  ------------------------------*/

--- a/navbits.c
+++ b/navbits.c
@@ -1,4 +1,4 @@
-/* navbits.c : 產生 B1I D1 子帧 (星曆) */
+/* navbits.c : 產生 B1I D1 子幀 (星曆) */
 
 #include <math.h>
 #include <string.h>
@@ -73,7 +73,7 @@ static void frame_from_ephemeris(const ephemeris_t *e, B1I_D1_Frame *f)
     }
 }
 
-/* --------------------------------- 宏 & 工具 -------------------------------- */
+/* --------------------------- 宏與工具 ------------------------------*/
 
 /* 填 30-bit word 至 bit 流。pos 為 bit index 0..299 (MSB first) */
 static void put_word(uint8_t *b, int pos, uint32_t w30)
@@ -82,12 +82,12 @@ static void put_word(uint8_t *b, int pos, uint32_t w30)
         b[pos+i] = (w30>>(29-i)) & 1;
 }
 
-/* --------------------------------- 子帧 1 ----------------------------------- */
+/* --------------------------- 子幀 1 ------------------------------*/
 static void build_subframe1_d1(uint8_t *out, const B1I_D1_Frame *f, int week, double sow, double frame_len)
 {
     memset(out,0,SF_STREAM_LEN);
 
-    /* word1：帧同步 11 bits（11100010010） + FraID(001) + SOW[19:12] */
+    /* word1：幀同步 11 bits（11100010010） + FraID(001) + SOW[19:12] */
     uint32_t info = 0x712;            /* 11-bit preamble */
     info = (info << 4);               /* reserved bits */
     info = (info << 3) | 0x1;         /* FraID=001 */
@@ -138,7 +138,7 @@ static void build_subframe1_d1(uint8_t *out, const B1I_D1_Frame *f, int week, do
     put_word(out,270, build_word(w10,22));
 }
 
-/* --------------------------------- 子帧 2 ----------------------------------- */
+/* --------------------------- 子幀 2 ------------------------------*/
 static void build_subframe2_d1(uint8_t *out, const B1I_D1_Frame *f, double sow, double frame_len)
 {
     memset(out, 0, SF_STREAM_LEN);
@@ -190,7 +190,7 @@ static void build_subframe2_d1(uint8_t *out, const B1I_D1_Frame *f, double sow, 
     put_word(out, 270, build_word(w10, 22));
 }
 
-/* --------------------------------- 子帧 3 ----------------------------------- */
+/* --------------------------- 子幀 3 ------------------------------*/
 static void build_subframe3_d1(uint8_t *out, const B1I_D1_Frame *f, double sow, double frame_len)
 {
     memset(out, 0, SF_STREAM_LEN);
@@ -242,7 +242,7 @@ static void build_subframe3_d1(uint8_t *out, const B1I_D1_Frame *f, double sow, 
     put_word(out, 270, build_word(w10, 22));
 }
 
-/* --------------------------------- 子帧 4 ----------------------------------- */
+/* --------------------------- 子幀 4 ------------------------------*/
 static void build_subframe4_d1(uint8_t *out, double sow, double frame_len)
 {
     /* Subframe 4 carries almanac pages.  Actual parameters are not yet
@@ -274,7 +274,7 @@ static void build_subframe4_d1(uint8_t *out, double sow, double frame_len)
     put_word(out, 270, build_word(w10, 22));
     
 }
-/* --------------------------------- 子帧 5 ----------------------------------- */
+/* --------------------------- 子幀 5 ------------------------------*/
 static void build_subframe5_d1(uint8_t *out, double sow, double frame_len)
 {
     /* Identical to subframe 4 but with FraID=5.  Data words use the same
@@ -308,8 +308,7 @@ static void build_subframe5_d1(uint8_t *out, double sow, double frame_len)
     put_word(out, 270, build_word(filler, 22));
 }
 
-
-/* 根據時間取得子帧 bit 流 (300 bits) */
+/* --------------------------- 根據時間取得子幀 bit 流 (300 bits) ------------------------------*/
 void get_subframe_bits(int prn,int sf_id,int week,double sow,double frame_len,uint8_t *out)
 {
     double start = floor(sow/frame_len)*frame_len;
@@ -334,7 +333,7 @@ void get_subframe_bits(int prn,int sf_id,int week,double sow,double frame_len,ui
     }
 }
 
-/* Dump broadcast ephemeris parameters for a given PRN */
+/* --------------------------- Dump broadcast ephemeris parameters for a given PRN ------------------------------*/
 void print_ephemeris_params(int prn)
 {
     B1I_D1_Frame f;
@@ -355,4 +354,4 @@ void print_ephemeris_params(int prn)
     printf("[PRN %d] omegadot=%d idot=%d cic=%d cis=%d\n",
            prn, f.omegadot, f.idot, f.cic, f.cis);
 }
-
+/* ---------------------------  End  ------------------------------*/

--- a/orbits.c
+++ b/orbits.c
@@ -1,6 +1,4 @@
-/* ---------------------------------------------------------------
- *  orbits.c
- * --------------------------------------------------------------*/
+/* --------------------------- orbits.c ------------------------------*/
 
 #include <stdio.h>
 #include <math.h>
@@ -10,9 +8,7 @@
 
 #define GM        3.986004418e14       /* WGS-84 μ  (m^3/s^2) */
 
-
-/* --------------------------------------------------------------*/
-/*             小工具：解 Kepler 方程 E − e·sinE = M             */
+/* --------------------------- 解 Kepler 方程 E − e·sinE = M ------------------------------*/
 static double kepler(double M, double e)
 {
     double E = M, d;
@@ -23,42 +19,40 @@ static double kepler(double M, double e)
     return E;
 }
 
-/* --------------------------------------------------------------*/
-/*          主要 API：回傳 ECEF at t_tx 的位置 xyz 與速度 vel      */
+/* --------------------------- 回傳衛星在 t_tx 的 ECEF 位置與速度 ------------------------------*/
 void calc_sat_position_velocity(int prn, int week, double sow,
                                 double *xyz, double *vel, double *clk)
 {
     const ephemeris_t *ep = &eph[prn];        /* 全域星曆陣列 (外部定義) */
 
-    /*          輸出保底值 (PRN 不存在)                             */
+    /* 輸出保底值 (PRN 不存在) */
     if (ep->prn == 0) {
         xyz[0] = xyz[1] = xyz[2] = 0.0;
         if (vel) vel[0] = vel[1] = vel[2] = 0.0;
         return;
     }
 
-
-    /* -------- tk: 時間差 (ToE → 模擬時刻)，處理週界溢位 ------- */
+    /* tk: 時間差 (ToE → 模擬時刻)，處理週界溢位 */
     const double t_sim = week * 604800.0 + sow;
     const double t_toe = ep->week * 604800.0 + ep->toe;
     double tk = t_sim - t_toe;
     if (tk >  302400.0) tk -= 604800.0;
     if (tk < -302400.0) tk += 604800.0;
 
-    /* -------- 基本軌道參數 & 平近點角 -------------------------- */
+    /* 基本軌道參數 & 平近點角 */
     const double A   = ep->sqrtA * ep->sqrtA;
     const double n0  = sqrt(GM / (A * A * A));
     const double n   = n0 + ep->deltan;
     const double M   = ep->M0 + n * tk;
     const double E   = kepler(M, ep->e);
 
-    /* 真近點角 ν 與引數 φ = ν + ω                               */
+    /* 真近點角 ν 與引數 φ = ν + ω */
     const double sinE = sin(E);
     const double cosE = cos(E);
     const double nu   = atan2(sqrt(1 - ep->e * ep->e) * sinE, cosE - ep->e);
     const double phi  = nu + ep->w;
 
-    /* -------- 攝動修正 ---------------------------------------- */
+    /* 攝動修正 */
     const double du = ep->cus * sin(2 * phi) + ep->cuc * cos(2 * phi);
     const double dr = ep->crs * sin(2 * phi) + ep->crc * cos(2 * phi);
     const double di = ep->cis * sin(2 * phi) + ep->cic * cos(2 * phi);
@@ -70,12 +64,12 @@ void calc_sat_position_velocity(int prn, int week, double sow,
     const double x_op = r * cos(u);
     const double y_op = r * sin(u);
 
-    /* -------- RAAN Ω(t) -------------------------------------- */
+    /* RAAN Ω(t) */
     /* Use unified RAAN expression for all BeiDou satellites
-     * Ω(t) = Ω₀ + (Ω̇ − Ωₑ) · tk − Ωₑ · Toe */
+ * Ω(t) = Ω₀ + (Ω̇ − Ωₑ) · tk − Ωₑ · Toe */
     double Omega = ep->omega0 + (ep->omegadot - OMEGA_E) * tk - OMEGA_E * ep->toe;
 
-    /* -------- ECEF at transmit time t_tx ----------------------- */
+    /* ECEF at transmit time t_tx */
     const double cosO = cos(Omega), sinO = sin(Omega);
     const double cosi = cos(i),     sini = sin(i);
 
@@ -83,7 +77,7 @@ void calc_sat_position_velocity(int prn, int week, double sow,
     const double y = x_op * sinO + y_op * cosi * cosO;
     const double z = y_op * sini;
 
-    /* ---- 若需要速度，直接在 ECEF 框架求導 --------------------- */
+    /* 若需要速度，直接在 ECEF 框架求導 */
     double x_dot = 0.0, y_dot = 0.0, z_dot = 0.0;
     if (vel) {
         const double Edot   = n / (1 - ep->e * cosE);
@@ -110,7 +104,7 @@ void calc_sat_position_velocity(int prn, int week, double sow,
         z_dot = y_op_dot * sini + y_op * cosi * i_dot;
     }
 
-    /* -------- 衛星鐘差 (含相對論效應與 TGD1) ----------------- */
+    /* 衛星鐘差 (含相對論效應與 TGD1) */
     if (clk) {
         const double relativistic = -4.442807633e-10 * ep->e * ep->sqrtA * sinE;
         const double t_clk_ref = ep->week * 604800.0 + ep->toc;

--- a/path.c
+++ b/path.c
@@ -166,4 +166,4 @@ void interpolate_path_llh(const path_t *path,double t,double llh[3])
     for(int k=0;k<3;++k)
         llh[k]=path->p[i].llh[k]*(1.0-f)+path->p[i+1].llh[k]*f;
 }
-
+/* ---------------------------  End  ------------------------------*/

--- a/rinex.c
+++ b/rinex.c
@@ -1,6 +1,5 @@
-/* rinex.c  –  解析 BDS RINEX3.04 NAV，僅提取 MEO/IGSO D1 需要的欄位
- *            (c) 2025  your-name
- * ------------------------------------------------------------------------ */
+/* rinex.c – 解析 BDS RINEX3.04 NAV，僅提取 MEO/IGSO D1 需要的欄位
+ * (c) 2025 your-name */
 
 #include "timeconv.h"
 #include <stdio.h>
@@ -13,7 +12,7 @@
 #include "bdssim.h"
 #include "globals.h"
 
-/* ---------- 小工具 ---------- */
+/* --------------------------- 小工具 ------------------------------*/
 static double fld(const char *ln, int idx, int ind)
 {
     char buf[20];
@@ -32,9 +31,9 @@ static int ifld(const char *ln, int idx, int ind)
     return (int)fld(ln, idx, ind);
 }
 
-/* very-tiny, zone-less timegm (UTC→UNIX)  –  只考慮閏年規則，可跨平台 */
+/* --------------------------- very-tiny, zone-less timegm (UTC→UNIX)  –  只考慮閏年規則，可跨平臺 ------------------------------*/
 
-/* ---------- 主要解析 ---------- */
+/* --------------------------- 主要解析 ------------------------------*/
 int read_rinex_nav(const char *fname, double start_bdt)
 {
     FILE *fp = fopen(fname, "r");
@@ -42,7 +41,7 @@ int read_rinex_nav(const char *fname, double start_bdt)
 
     char l[120];
 
-    /* parse header -------------------------------------------------- */
+    /* parse header */
     while (fgets(l, sizeof(l), fp))
     {
         if(strncmp(l,"BDSA",4)==0){
@@ -82,7 +81,7 @@ int read_rinex_nav(const char *fname, double start_bdt)
         ephemeris_t tmp = {0};
         tmp.prn = prn;
 
-        /* ── 1st row：時間戳記與 af0/1/2 -------------------------- */
+        /* 1st row：時間戳記與 af0/1/2 */
         int yy, mm, dd, hh, mi;
         double ss;
         int w_dummy; double sow;
@@ -100,9 +99,8 @@ int read_rinex_nav(const char *fname, double start_bdt)
         tmp.af1 = fld(l, 1, IND1);
         tmp.af2 = fld(l, 2, IND1);
 
-        /* ── 讀後 7 行 -------------------------------------------- */
+        /* 讀後 7 行 */
 
-        /* ── 讀後 7 行 -------------------------------------------- */
         char r[7][120];
         for (int i = 0; i < 7; ++i)
             if (!fgets(r[i], sizeof r[i], fp)) return -1;
@@ -158,4 +156,4 @@ int read_rinex_nav(const char *fname, double start_bdt)
     puts("[rinex] 北斗星曆已載入");
     return 0;
 }
-
+/* ---------------------------  End  ------------------------------*/


### PR DESCRIPTION
## Summary
- restore dashed banner comments and end markers across C sources for consistent style
- remove residual gps-sdr-sim references from channel amplitude logic

## Testing
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_68ad8742749c8327beb2fa17d74ef741