### PR TITLE
Add ionospheric delay calculation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,41 +3,45 @@ CC      = gcc
 CFLAGS = -I. -O2 -Wall -Wextra -fopenmp -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE
 
 OBJS = main.o globals.o bch.o navbits.o channel.o \
-        bdssim.o rinex.o orbits.o coord.o path.o
-	
+	bdssim.o rinex.o orbits.o coord.o path.o iono.o
+
 bds-sim: $(OBJS)
 	$(CC) $(CFLAGS) -o $@ $(OBJS) -lm
 
-tests/prn_test: tests/prn_test.o globals.o bch.o navbits.o channel.o rinex.o orbits.o coord.o path.o bdssim.o
+tests/prn_test: tests/prn_test.o globals.o bch.o navbits.o channel.o rinex.o orbits.o coord.o path.o bdssim.o iono.o
 	$(CC) $(CFLAGS) $^ -o $@ -lm
 
 tests/test_beidou: tests/test_beidou.c
 	$(CC) $(CFLAGS) $< -o $@
 
-tests/test_prn: tests/test_prn.o globals.o bch.o navbits.o channel.o rinex.o orbits.o coord.o path.o bdssim.o
+tests/test_prn: tests/test_prn.o globals.o bch.o navbits.o channel.o rinex.o orbits.o coord.o path.o bdssim.o iono.o
 	$(CC) $(CFLAGS) $^ -o $@ -lm
 
-tests/test_nh_prn: tests/test_nh_prn.o globals.o bch.o navbits.o channel.o rinex.o orbits.o coord.o path.o bdssim.o
+tests/test_nh_prn: tests/test_nh_prn.o globals.o bch.o navbits.o channel.o rinex.o orbits.o coord.o path.o bdssim.o iono.o
 	$(CC) $(CFLAGS) $^ -o $@ -lm
 
-tests/test_orbits: tests/test_orbits.o globals.o bch.o navbits.o channel.o rinex.o orbits.o coord.o path.o bdssim.o
+tests/test_orbits: tests/test_orbits.o globals.o bch.o navbits.o channel.o rinex.o orbits.o coord.o path.o bdssim.o iono.o
 	$(CC) $(CFLAGS) $^ -o $@ -lm
 
 tests/test_timeconv: tests/test_timeconv.c
 	$(CC) $(CFLAGS) $< -o $@
 
-check: tests/test_prn tests/test_nh_prn
+tests/test_iono: tests/test_iono.o iono.o
+	$(CC) $(CFLAGS) $^ -o $@ -lm
+
+check: tests/test_prn tests/test_nh_prn tests/test_iono
 	./tests/test_prn
 	./tests/test_nh_prn
+	./tests/test_iono
 
 %.o: %.c
 	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
 	rm -f *.o bds-sim tests/prn_test tests/test_beidou \
-        tests/test_prn tests/test_nh_prn tests/test_nh_prn.o \
-        tests/test_orbits tests/test_orbits.o \
-        tests/test_timeconv *.bin *.gz
+	tests/test_prn tests/test_nh_prn tests/test_nh_prn.o \
+	tests/test_orbits tests/test_orbits.o \
+	tests/test_timeconv *.bin *.gz
 	@echo "已清除中間檔與 .gz 暫存檔"
 
 # =====================[ 下載區 ]=====================
@@ -53,19 +57,19 @@ download-%:
 	@NAME_LOWER=$*; \
 	NAME=$$(echo $$NAME_LOWER | tr a-z A-Z); \
 	if echo $$NAME | grep -q '^BRDM'; then \
-		# ------------- BRDM (多GNSS) ------------- \
-		YEAR=$$(echo $$NAME | cut -c5-8); \
-		DOY=$$(echo $$NAME | cut -c9-11); \
-		FILE=BRDM00DLR_S_$${YEAR}$${DOY}0000_01D_MN.rnx.gz; \
-		SUBDIR=brdm; \
+	        # ------------- BRDM (多GNSS) ------------- \
+	        YEAR=$$(echo $$NAME | cut -c5-8); \
+	        DOY=$$(echo $$NAME | cut -c9-11); \
+	        FILE=BRDM00DLR_S_$${YEAR}$${DOY}0000_01D_MN.rnx.gz; \
+	        SUBDIR=brdm; \
 	elif echo $$NAME | grep -q '^BRDC'; then \
-		# ------------- BRDC (GPS/GLONASS) -------- \
-		YEAR=20$$(echo $$NAME | sed 's/.*\.\([0-9][0-9]\)N/\1/' ); \
-		DOY=$$(echo $$NAME | cut -c5-7); \
-		FILE=$${NAME}.gz; \
-		SUBDIR=brdc; \
+	        # ------------- BRDC (GPS/GLONASS) -------- \
+	        YEAR=20$$(echo $$NAME | sed 's/.*\.\([0-9][0-9]\)N/\1/' ); \
+	        DOY=$$(echo $$NAME | cut -c5-7); \
+	        FILE=$${NAME}.gz; \
+	        SUBDIR=brdc; \
 	else \
-		echo "無法辨識檔名 $$NAME_LOWER"; exit 1; \
+	        echo "無法辨識檔名 $$NAME_LOWER"; exit 1; \
 	fi; \
 	URL=https://cddis.nasa.gov/archive/gnss/data/daily/$${YEAR}/brdc/$$FILE; \
 	echo "下載 $$URL"; \
@@ -73,15 +77,14 @@ download-%:
 	     -H "User-Agent: Mozilla/5.0" \
 	     -o $$FILE $$URL; \
 	if grep -q '<html' $$FILE; then \
-		echo "下載失敗，收到 HTML 錯誤頁 (未授權?)"; \
-		rm -f $$FILE; exit 1; \
+	        echo "下載失敗，收到 HTML 錯誤頁 (未授權?)"; \
+	        rm -f $$FILE; exit 1; \
 	fi; \
 	if file $$FILE | grep -q 'gzip compressed'; then \
-		gunzip -f $$FILE; \
-		echo "解壓完成 → $${FILE%.gz}"; \
+	        gunzip -f $$FILE; \
+	        echo "解壓完成 → $${FILE%.gz}"; \
 	else \
-		echo "檔案已是解壓狀態：$$FILE"; \
+	        echo "檔案已是解壓狀態：$$FILE"; \
 	fi
 
 .PHONY: all clean download-%
-

--- a/bdssim.c
+++ b/bdssim.c
@@ -11,6 +11,7 @@
 #include "navbits.h"
 #include "timeconv.h"
 #include "path.h"
+#include "iono.h"
 #define FSAMP_DEF FS_OUTPUT_HZ    /* default 5.2 MHz for 16-bit I/Q output */
 #define FSAMP_BYTE 25.0e6    /* 25 MHz when --byte is used */
 #define IF_BYTE    0.0       /* baseband (0 Hz IF) for --byte output */
@@ -134,6 +135,13 @@ int select_channels(channel_t *ch,int *n,const coord_t*u,
         compute_range_rate(prn,u->week,u->sow,u,NULL,sat,NULL,&rho,&rdot,NULL);
         double enu[3]; ecef_to_enu(u,sat,enu);
         double el=enu_elevation_deg(enu); if(el<5.0)continue;
+        double az_deg = atan2(enu[0], enu[1]) * 180.0 / M_PI;
+        double lat_deg = u->llh[0] * 180.0 / M_PI;
+        double lon_deg = u->llh[1] * 180.0 / M_PI;
+        if(g_enable_iono)
+            rho += iono_delay(lat_deg, lon_deg, az_deg, el,
+                               u->sow, iono_alpha, iono_beta,
+                               F_B1I, F_B1I, NULL);
         c[m++] = (struct cand){prn,el,rho,rdot};
     }
     /* sort by elevation (desc) */
@@ -175,6 +183,13 @@ static void update_channels_path(channel_t *ch,int n,
         double enu[3]; ecef_to_enu(u,sat[i],enu);
         el[i] = enu_elevation_deg(enu);
         if(el[i] >= 5.0) n_vis_now++;
+        double az_deg = atan2(enu[0], enu[1]) * 180.0 / M_PI;
+        double lat_deg = u->llh[0] * 180.0 / M_PI;
+        double lon_deg = u->llh[1] * 180.0 / M_PI;
+        if(g_enable_iono)
+            rho[i] += iono_delay(lat_deg, lon_deg, az_deg, el[i],
+                                 u->sow, iono_alpha, iono_beta,
+                                 F_B1I, F_B1I, NULL);
 
         double sat2[3];
         compute_range_rate(prn,week2,sow2,u_next,uvel_next,
@@ -182,6 +197,13 @@ static void update_channels_path(channel_t *ch,int n,
         double enu2[3]; ecef_to_enu(u_next,sat2,enu2);
         el2[i] = enu_elevation_deg(enu2);
         if(el2[i] >= 5.0) n_vis_next++;
+        double az2_deg = atan2(enu2[0], enu2[1]) * 180.0 / M_PI;
+        double lat2_deg = u_next->llh[0] * 180.0 / M_PI;
+        double lon2_deg = u_next->llh[1] * 180.0 / M_PI;
+        if(g_enable_iono)
+            rho2[i] += iono_delay(lat2_deg, lon2_deg, az2_deg, el2[i],
+                                  sow2, iono_alpha, iono_beta,
+                                  F_B1I, F_B1I, NULL);
         fd2[i] = -F_B1I*rdot2[i]/CLIGHT;
         cr2[i] = CHIPRATE*(1.0 - rdot2[i]/CLIGHT);
     }

--- a/bdssim.h
+++ b/bdssim.h
@@ -26,6 +26,7 @@ typedef struct {
     bool     meo_only;
     int      single_prn;
     bool     prn37_only;
+    bool     iono_on;
 } sim_config_t;
 
 bool init_simulator(sim_config_t *, double start_bdt);

--- a/globals.c
+++ b/globals.c
@@ -26,6 +26,9 @@ int prn_max = 63;
 /* Global transmit time (BDT seconds) */
 double g_t_tx = 0.0;
 
+/* Enable/disable ionospheric delay model */
+int g_enable_iono = 1;
+
 /* --------------------------- B1I PRN 產生 ------------------------------*/
 #define ITER 2047                     /* 先跑滿 2047，再丟掉最後 1 chip */
 

--- a/globals.h
+++ b/globals.h
@@ -4,6 +4,11 @@
 
 #include <stdint.h>
 
+/* Some platforms do not define M_PI in math.h */
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
 /* Physical and signal constants */
 #define CLIGHT      299792458.0    /* Speed of light (m/s) */
 #define F_B1I       1561.098e6     /* B1I carrier frequency (Hz) */
@@ -50,6 +55,7 @@ extern double iono_beta[4];
 extern int utc_bdt_diff;
 extern double g_t_tx;
 extern double g_target_cn0;
+extern int g_enable_iono;
 
 #endif /* GLOBALS_H */
 

--- a/iono.c
+++ b/iono.c
@@ -1,0 +1,105 @@
+#include <math.h>
+#include <float.h>
+#include "globals.h"  /* CLIGHT, M_PI */
+#include "iono.h"
+
+/* Compute ionospheric delay using Klobuchar model.
+ * Inputs are in degrees and seconds; alpha/beta coefficients follow
+ * broadcast convention.  Frequencies are in Hz.
+ * Returns slant delay in meters and fills optional debug structure.
+ */
+
+double iono_delay(double lat_deg, double lon_deg,
+                  double az_deg, double el_deg,
+                  double sow, const double alpha[4], const double beta[4],
+                  double f, double f_ref, iono_res_t *out)
+{
+    /* Convert degrees to semicircles */
+    double phi_u = lat_deg / 180.0;
+    double lam_u = lon_deg / 180.0;
+    double az    = az_deg  / 180.0;
+    double el    = el_deg  / 180.0;
+
+    /* Clamp elevation to [0,0.9] semicircles (0°–162°) */
+    if (el < 0.0) el = 0.0;
+    else if (el > 0.9) el = 0.9;
+
+    /* Wrap SOW to [0,86400) */
+    sow = fmod(sow, 86400.0);
+    if (sow < 0.0) sow += 86400.0;
+
+    /* 1. Slant factor F */
+    double tmp = 0.53 - el;
+    double F = 1.0 + 16.0 * tmp * tmp * tmp;
+
+    /* 2. Earth-centered angle psi */
+    double psi = 0.0137 / (el + 0.11) - 0.022;
+
+    /* 3. Sub-ionospheric latitude phi_i */
+    double phi_i = phi_u + psi * cos(M_PI * az);
+    if (phi_i > 0.416) phi_i = 0.416;
+    if (phi_i < -0.416) phi_i = -0.416;
+
+    /* 4. Sub-ionospheric longitude lambda_i */
+    double cos_phi = cos(M_PI * phi_i);
+    if (fabs(cos_phi) < 1e-12)
+        cos_phi = cos_phi >= 0.0 ? 1e-12 : -1e-12;
+    double lambda_i = lam_u + (psi * sin(M_PI * az)) / cos_phi;
+
+    /* Normalize lambda_i to [-1,+1] semicircles */
+    if (lambda_i > 1.0 || lambda_i < -1.0)
+        lambda_i -= floor((lambda_i + 1.0) / 2.0) * 2.0;
+
+    /* 5. Geomagnetic latitude phi_m */
+    double phi_m = phi_i + 0.064 * cos(M_PI * (lambda_i - 1.617));
+
+    /* 6. Local time t_local */
+    double t_local = 43200.0 * lambda_i + sow;
+    t_local = fmod(t_local, 86400.0);
+    if (t_local < 0.0) t_local += 86400.0;
+
+    /* 7. Amplitude A */
+    double phi_m2 = phi_m * phi_m;
+    double phi_m3 = phi_m2 * phi_m;
+    double A = alpha[0] + alpha[1]*phi_m + alpha[2]*phi_m2 + alpha[3]*phi_m3;
+    if (A < 0.0) A = 0.0;
+
+    /* 8. Period P */
+    double P = beta[0] + beta[1]*phi_m + beta[2]*phi_m2 + beta[3]*phi_m3;
+    if (P < 72000.0) P = 72000.0;
+
+    /* 9. Phase x */
+    double x = 2.0 * M_PI * (t_local - 50400.0) / P;
+
+    /* 10. Vertical delay I_vert */
+    double I_vert;
+    if (fabs(x) < (M_PI/2))
+        I_vert = 5e-9 + A * (1.0 - x*x/2.0 + (x*x*x*x)/24.0);
+    else
+        I_vert = 5e-9;
+
+    /* 11. Slant delay seconds */
+    double I_slant = F * I_vert;
+
+    /* 12. Frequency mapping */
+    if (f > 0.0 && f_ref > 0.0) {
+        double ratio = f_ref / f;
+        I_slant *= ratio * ratio;
+    }
+
+    /* 13. Convert to meters */
+    double delay_m = CLIGHT * I_slant;
+
+    if (out) {
+        out->F = F;
+        out->psi = psi;
+        out->phi_i = phi_i;
+        out->lambda_i = lambda_i;
+        out->phi_m = phi_m;
+        out->t_local = t_local;
+        out->I_vert = I_vert;
+        out->I_slant = I_slant;
+        out->delay_m = delay_m;
+    }
+    return delay_m;
+}

--- a/iono.h
+++ b/iono.h
@@ -1,0 +1,25 @@
+#ifndef IONO_H
+#define IONO_H
+
+typedef struct {
+    double F;        /* slant factor */
+    double psi;      /* earth-centered angle */
+    double phi_i;    /* sub-ionospheric latitude (semicircle) */
+    double lambda_i; /* sub-ionospheric longitude (semicircle) */
+    double phi_m;    /* geomagnetic latitude (semicircle) */
+    double t_local;  /* local time (s) */
+    double I_vert;   /* vertical delay (s) */
+    double I_slant;  /* slant delay (s) */
+    double delay_m;  /* slant delay (m) */
+} iono_res_t;
+
+/* Compute Klobuchar ionospheric delay.  Returns slant-path delay in meters.
+ * Add this value to the geometric range for pseudorange; subtract the
+ * equivalent phase (delay_m / wavelength) from carrier phase measurements.
+ */
+double iono_delay(double lat_deg, double lon_deg,
+                  double az_deg, double el_deg,
+                  double sow, const double alpha[4], const double beta[4],
+                  double f, double f_ref, iono_res_t *out);
+
+#endif /* IONO_H */

--- a/main.c
+++ b/main.c
@@ -28,6 +28,7 @@ static void usage(const char *p)
     puts("  --meo-only          僅模擬 MEO 衛星");
     puts("  --prn N             僅模擬指定 PRN");
     puts("  --prn37             僅使用 1-37 號衛星");
+    puts("  --no-iono           停用電離層延遲模型");
     puts("  --help               顯示本說明\n");
 }
 
@@ -44,6 +45,7 @@ int main(int argc,char *argv[])
     cfg.meo_only   = false;
     cfg.single_prn = 0;
     cfg.prn37_only = false;
+    cfg.iono_on    = true;
     bool llh_given   = false;
 
     /* 處理 "-byte" 舊習慣 */
@@ -77,12 +79,13 @@ int main(int argc,char *argv[])
         {"meo-only", no_argument,       0, 'M'},
         {"prn",      required_argument, 0, 'p'},
         {"prn37",    no_argument,       0, 'B'},
+        {"no-iono",  no_argument,       0, 'I'},
         {"help",     no_argument,       0, 'h'},
         {0,0,0,0}
     };
 
     int c, idx;
-    while((c = getopt_long(argc, argv, "e:t:l:x:y:n:d:g:R:hbp:BM", longopt, &idx)) != -1){
+    while((c = getopt_long(argc, argv, "e:t:l:x:y:n:d:g:R:hbp:BMI", longopt, &idx)) != -1){
         switch(c){
         case 'e':
             strncpy(cfg.rinex_file, optarg, sizeof(cfg.rinex_file)-1);
@@ -139,6 +142,10 @@ int main(int argc,char *argv[])
         case 'B':
             cfg.prn37_only = true;
             break;
+        case 'I':
+            cfg.iono_on = false;
+            g_enable_iono = 0;
+            break;
         case 'h':
             usage(argv[0]);
             return 0;
@@ -151,6 +158,8 @@ int main(int argc,char *argv[])
     if(cfg.rinex_file[0]=='\0' || cfg.time_start[0]=='\0'){
         usage(argv[0]); return 1;
     }
+
+    g_enable_iono = cfg.iono_on ? 1 : 0;
 
     if(cfg.path_type!=0 && llh_given){
         fputs("--llh 與路徑檔選項不可並用\n", stderr);

--- a/tests/test_iono.c
+++ b/tests/test_iono.c
@@ -1,0 +1,21 @@
+#include <stdio.h>
+#include <math.h>
+#include "iono.h"
+
+int main(void)
+{
+    double lat = 25.0, lon = 121.0;
+    double az = 45.0, el = 30.0;
+    double sow = 45000.0;
+    double alpha[4] = {2.1420e-08, 5.9605e-08, -6.5565e-07, 1.0729e-06};
+    double beta[4]  = {1.1264e5, 9.8304e4, 4.5875e5, -5.8982e5};
+    double f = 1561.098e6, f_ref = 1561.098e6;
+    iono_res_t out;
+    double delay = iono_delay(lat, lon, az, el, sow, alpha, beta, f, f_ref, &out);
+    if (fabs(delay - 6.6258123807814675) > 1e-6) {
+        fprintf(stderr, "Unexpected delay: %.12f m\n", delay);
+        return 1;
+    }
+    printf("Delay: %.6f m\n", delay);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- refine Klobuchar ionosphere model with robust angle handling and frequency mapping
- apply ionospheric delay to satellite ranges in channel selection and updates
- document pseudorange vs carrier-phase usage and add missing math constants
- add `--no-iono` flag to disable ionospheric corrections at runtime

## Testing
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_68adcea8aedc8327a5008554d7555e6b