### PR TITLE
feat: add configurable sample rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 BDS-SDRSIM is an open-source C simulator that synthesizes BeiDou B1I baseband signals for software-defined radio experiments.（BDS-SDRSIM 是一個以 C 語言撰寫的開源模擬器，可產生北斗 B1I 基帶訊號供 SDR 測試）
 
 ## Features
-- **Signal output**: Generates interleaved I/Q samples in 16-bit (5.2 MHz) or 8-bit (25 MHz) format.（輸出 16 位元或 8 位元的 I/Q 樣本）
+- **Signal output**: Generates interleaved I/Q samples in 16-bit or 8-bit format with configurable sample rate (default 5.2 MHz or 25 MHz with `--byte`).（輸出 16 位元或 8 位元的 I/Q 樣本，可設定取樣率，預設為 5.2 MHz，`--byte` 模式為 25 MHz）
 - **Navigation data**: Builds D1 subframes from RINEX ephemeris and inserts 20‑bit Neumann–Hoffman codes.（從 RINEX 星曆產生 D1 子幀並加入 20 位元 Neumann–Hoffman 序列）
 - **Multi-satellite channels**: Automatically selects visible PRNs or restricts to user-specified sets.（自動選取可視衛星或依參數限制 PRN）
 - **User motion**: Supports fixed LLH coordinates or 1 Hz trajectory files (`--xyz`, `--llh-file`, `--nmea`).（可模擬靜止或動態使用者）
@@ -79,6 +79,7 @@ BDS-SDRSIM is an open-source C simulator that synthesizes BeiDou B1I baseband si
 | `--llh lat,lon,h` | Fixed user position in degrees/meters.（固定使用者位置） |
 | `--xyz/--llh-file/--nmea file` | 1 Hz trajectory file for moving user.（匯入路徑檔模擬移動） |
 | `--gain amp` | Output amplitude gain (>0).（輸出振幅倍率） |
+| `--fs MHz` | Sample rate in MHz (default 5.2 or 25 with `--byte`).（設定取樣率，預設 5.2 MHz；`--byte` 模式 25 MHz） |
 | `-cn0 value` | Target C/N₀ to balance channel power.（目標 C/N₀） |
 | `--byte` | Output 8‑bit I/Q at 25 MHz.（以 8 位元輸出 25 MHz 樣本） |
 | `--meo-only` | Use only MEO satellites.（僅模擬 MEO 衛星） |

--- a/bdssim.c
+++ b/bdssim.c
@@ -12,8 +12,8 @@
 #include "timeconv.h"
 #include "path.h"
 #include "iono.h"
-#define FSAMP_DEF FS_OUTPUT_HZ    /* default 5.2 MHz for 16-bit I/Q output */
-#define FSAMP_BYTE 25.0e6    /* 25 MHz when --byte is used */
+#define FSAMP_DEF  FS_OUTPUT_HZ    /* default 5.2 MHz for 16-bit I/Q output */
+#define FSAMP_BYTE FS_BYTE_HZ      /* 25 MHz when --byte is used */
 #define IF_BYTE    0.0       /* baseband (0 Hz IF) for --byte output */
 
 /* --------------------------- 振幅計算與 int16 飽和保護 ------------------------------*/
@@ -266,7 +266,7 @@ void generate_signal(const sim_config_t *cfg)
     select_channels(ch,&n_ch,&usr,cfg->single_prn,
                     cfg->meo_only);
 
-    double fs = cfg->byte_output ? FSAMP_BYTE : FSAMP_DEF;
+    double fs = cfg->fs;
     int samp_per_ms = (int)(fs/1000.0 + 0.5);
     channel_set_fs(fs);                   /* ensure dynamics use correct Fs */
 

--- a/bdssim.h
+++ b/bdssim.h
@@ -23,6 +23,7 @@ typedef struct {
     double   target_cn0;
     unsigned seed;
     bool     byte_output;
+    double   fs;           /* sample rate (Hz) */
     bool     meo_only;
     int      single_prn;
     bool     prn37_only;

--- a/globals.h
+++ b/globals.h
@@ -21,6 +21,7 @@
 
 /* Amplitude and sampling parameters */
 #define FS_OUTPUT_HZ    5200000.0
+#define FS_BYTE_HZ      25000000.0
 #define CN0_TARGET_DBHZ 42.0
 #define HEADROOM_RATIO  0.80
 #define AMP_SMOOTH_TC_MS 1000

--- a/main.c
+++ b/main.c
@@ -22,6 +22,7 @@ static void usage(const char *p)
     puts("  --nmea file          NMEA 路徑檔");
     puts("  --duration sec       模擬秒數 (1-3600)");
     puts("  --gain amp           輸出增益 (>0)");
+    puts("  --fs MHz            取樣率 (MHz)");
     puts("  -cn0 value          目標 CN0 (dB-Hz)");
     puts("  --seed n            亂數種子 (整數)");
     puts("  --byte               輸出 8-bit IQ 檔 (0 Hz IF)");
@@ -42,11 +43,13 @@ int main(int argc,char *argv[])
     cfg.duration    = 300;                /* 預設 300 秒 */
     cfg.seed        = 1;
     cfg.byte_output = false;
+    cfg.fs          = FS_OUTPUT_HZ;
     cfg.meo_only   = false;
     cfg.single_prn = 0;
     cfg.prn37_only = false;
     cfg.iono_on    = true;
     bool llh_given   = false;
+    bool fs_given    = false;
 
     /* 處理 "-byte" 舊習慣 */
     for(int i=1;i<argc;i++){
@@ -74,6 +77,7 @@ int main(int argc,char *argv[])
         {"nmea",     required_argument, 0, 'n'},
         {"duration", required_argument, 0, 'd'},
         {"gain",     required_argument, 0, 'g'},
+        {"fs",       required_argument, 0, 'f'},
         {"seed",     required_argument, 0, 'R'},
         {"byte",     no_argument,       0, 'b'},
         {"meo-only", no_argument,       0, 'M'},
@@ -85,7 +89,7 @@ int main(int argc,char *argv[])
     };
 
     int c, idx;
-    while((c = getopt_long(argc, argv, "e:t:l:x:y:n:d:g:R:hbp:BMI", longopt, &idx)) != -1){
+    while((c = getopt_long(argc, argv, "e:t:l:x:y:n:d:g:f:R:hbp:BMI", longopt, &idx)) != -1){
         switch(c){
         case 'e':
             strncpy(cfg.rinex_file, optarg, sizeof(cfg.rinex_file)-1);
@@ -127,6 +131,10 @@ int main(int argc,char *argv[])
                 return 1;
             }
             break;
+        case 'f':
+            cfg.fs = atof(optarg) * 1e6;
+            fs_given = true;
+            break;
         case 'R':
             cfg.seed = (unsigned)strtoul(optarg,NULL,0);
             break;
@@ -160,6 +168,13 @@ int main(int argc,char *argv[])
     }
 
     g_enable_iono = cfg.iono_on ? 1 : 0;
+
+    if(cfg.byte_output && !fs_given)
+        cfg.fs = FS_BYTE_HZ;
+    if(cfg.fs <= 0.0){
+        fputs("--fs 必須 >0\n", stderr);
+        return 1;
+    }
 
     if(cfg.path_type!=0 && llh_given){
         fputs("--llh 與路徑檔選項不可並用\n", stderr);
@@ -266,7 +281,7 @@ int main(int argc,char *argv[])
     printf("\n[cfg] MEO:");
     for(int i=0;i<n_ch;i++)
         if(is_meo_prn(prn_sorted[i])) printf(" %02d", prn_sorted[i]);
-    double fs_out = cfg.byte_output ? 25.0 : FS_OUTPUT_HZ/1e6;
+    double fs_out = cfg.fs/1e6;
     printf("\n[cfg] Fs %.2fMHz  Gain %.2f\n\n",
            fs_out, cfg.gain);
 


### PR DESCRIPTION
## Summary
- add `--fs` option to configure output sample rate
- default to 5.2 MHz or 25 MHz when `--byte` is used
- document new option in README

## Testing
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_68b06875c1a483279f5a7fe020ebbe45